### PR TITLE
Fixes xsrf-token parsing

### DIFF
--- a/lib/bugsplat-api-client.ts
+++ b/lib/bugsplat-api-client.ts
@@ -63,8 +63,8 @@ export class BugSplatApiClient {
     private parseXsrfToken(cookie: string): string {
         const regex = new RegExp(/xsrf-token=[^;]*/g);
         const matches = Array.from(cookie.matchAll(regex));
-        const nonDeletedXsrfCookie = matches[1][0];
-        const xsrfToken = nonDeletedXsrfCookie.split('=')[1];
+        const xsrfCookie = matches[0][0];
+        const xsrfToken = xsrfCookie.split('=')[1];
         return xsrfToken;
     }
 }


### PR DESCRIPTION
We were returning set-cookie value to delete a legacy xsrf-cookie on another domain which was resulting in 2 xsrf-cookie regex matches. Now that we've removed the legacy cookie we match on the first instance os xsrf-cookie.

Fixes #14