### PR TITLE
Standardize Command-Line Parsing

### DIFF
--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -72,20 +72,29 @@ export const argDefinitions: Array<CommandLineDefinition> = [
 export const usageDefinitions: Array<Section> = [
     {
         header: '@bugsplat/symbol-upload',
-        content: '@bugsplat/symbol-upload contains a command line utility and set of libraries to help you upload symbols to BugSplat.',
+        content: 'symbol-upload contains a command line utility and set of libraries to help you upload symbols to BugSplat.',
     },
     {
         header: 'Usage',
-        content: 'symbol-upload -b {your-bugsplat-database} -a {your-application-name} -v {your-version} [ -f "*.js.map" -d "/path/to/containing/dir" -u {your-bugsplat-email} -p {your-bugsplat-password} ]',
         optionList: argDefinitions
     },
     {
-        content: 'The -u and -p arguments are optional if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD.'
+        header: 'Example',
+        content: [
+            'symbol-upload -b {italic your-bugsplat-database} -a {italic your-application-name} -v {italic your-version} [ -f "*.js.map" -d "/path/to/containing/dir" -u {italic your-bugsplat-email} -p {italic your-bugsplat-password} ]',
+            '',
+            'The -u and -p arguments are optional if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD.'
+        ]
     },
     {
-        content: '{underline https://github.com/BugSplat-Git/symbol-upload}'
-    },
-    {
-        content: '❤️ support@bugsplat.com'
+        header: 'Links',
+        content: 
+        [
+            '🐛 {underline https://bugsplat.com}',
+            '',
+            '💻 {underline https://github.com/BugSplat-Git/symbol-upload}',
+            '',
+            '💌 {underline support@bugsplat.com}'
+        ]
     }
 ];

--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -46,20 +46,6 @@ export const argDefinitions: Array<CommandLineDefinition> = [
         description: 'The password for your BugSplat account. Can also be provided via the SYMBOL_UPLOAD_PASSWORD environment variable. If provided --user must also be provided.',
     },
     {
-        name: 'clientId',
-        alias: 'i',
-        type: String,
-        typeLabel: '{underline string} (optional)',
-        description: 'An OAuth2 Client Credentials Client ID for the specified database. Can also be provided via the SYMBOL_UPLOAD_CLIENT_ID environment variable. If provided --clientSecret must also be provided.',
-    },
-    {
-        name: 'clientSecret',
-        alias: 's',
-        type: String,
-        typeLabel: '{underline string} (optional)',
-        description: 'An OAuth2 Client Credentials Client Secret for the specified database. Can also be provided via the SYMBOL_UPLOAD_CLIENT_SECRET environment variable. If provided --clientId must also be provided.',
-    },
-    {
         name: 'remove',
         alias: 'r',
         type: Boolean,
@@ -90,14 +76,14 @@ export const usageDefinitions: Array<Section> = [
     },
     {
         header: 'Usage',
-        content: 'symbol-upload -b {your-bugsplat-database} -a {your-application-name} -v {your-version} [ -f "*.js.map" -d "/path/to/containing/dir" [ -u {your-bugsplat-email} -p {your-bugsplat-password} ] OR [ -i {your-client-id} -s {your-client-secret} ] ]',
+        content: 'symbol-upload -b {your-bugsplat-database} -a {your-application-name} -v {your-version} [ -f "*.js.map" -d "/path/to/containing/dir" -u {your-bugsplat-email} -p {your-bugsplat-password} ]',
         optionList: argDefinitions
     },
     {
-        content: 'The -u and -p arguments are optional if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD, or provide a Client ID and Client Secret pair.'
+        content: 'The -u and -p arguments are optional if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD.'
     },
     {
-        content: 'The -i and -s arguments are optional if you set the environment variables SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET, or provide a user and password.'
+        content: 'The -i and -s arguments are optional if you set the environment variables SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET.'
     },
     {
         content: '{underline https://github.com/BugSplat-Git/symbol-upload}'

--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -83,9 +83,6 @@ export const usageDefinitions: Array<Section> = [
         content: 'The -u and -p arguments are optional if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD.'
     },
     {
-        content: 'The -i and -s arguments are optional if you set the environment variables SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET.'
-    },
-    {
         content: '{underline https://github.com/BugSplat-Git/symbol-upload}'
     },
     {

--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -22,34 +22,34 @@ export const argDefinitions: Array<CommandLineDefinition> = [
         alias: 'a',
         type: String,
         typeLabel: '{underline string}',
-        description: 'The name of your application used to post crash reports',
+        description: 'The name of your application. The value of application must match the value used to post crash reports.',
     },
     {
         name: 'version',
         alias: 'v',
         type: String,
         typeLabel: '{underline string}',
-        description: 'The version of your application used to post crash reports',
+        description: 'Your application\'s version. The value of version must match the value used to post crash reports.',
     },
     {
         name: 'user',
         alias: 'u',
         type: String,
         typeLabel: '{underline string} (optional)',
-        description: 'The email address of your BugSplat account. Can also be provided via the SYMBOL_UPLOAD_USER environment variable. If provided --password must also be provided.',
+        description: 'The email address used to log into your BugSplat account. If provided --password must also be provided. This value can also be provided via the SYMBOL_UPLOAD_USER environment variable.',
     },
     {
         name: 'password',
         alias: 'p',
         type: String,
         typeLabel: '{underline string} (optional)',
-        description: 'The password for your BugSplat account. Can also be provided via the SYMBOL_UPLOAD_PASSWORD environment variable. If provided --user must also be provided.',
+        description: 'The password for your BugSplat account. If provided --user must also be provided. This value can also be provided via the SYMBOL_UPLOAD_PASSWORD environment variable.',
     },
     {
         name: 'remove',
         alias: 'r',
         type: Boolean,
-        description: 'Removes symbols for specified database, application, version, and exits.'
+        description: 'Removes symbols for a specified database, application, and version. If this option is provided no other actions are taken.'
     },
     {
         name: 'files',
@@ -57,7 +57,7 @@ export const argDefinitions: Array<CommandLineDefinition> = [
         type: String,
         defaultValue: '*.js.map',
         typeLabel: '{underline string} (optional)',
-        description: 'Glob pattern specifying a file pattern to upload. Defaults to \'*.js.map\'',
+        description: 'Glob pattern that specifies a set of files to upload. Defaults to \'*.js.map\'',
     },
     {
         name: 'directory',
@@ -65,21 +65,21 @@ export const argDefinitions: Array<CommandLineDefinition> = [
         type: String,
         defaultValue: '.',
         typeLabel: '{underline string} (optional)',
-        description: 'Path to base directory to search for symbols and will be combined with the -f glob. Defaults to \'.\'',
+        description: 'Path of the base directory used to search for symbol files. This value will be combined with the --files glob. Defaults to \'.\'',
     }
 ];
 
 export const usageDefinitions: Array<Section> = [
     {
         header: '@bugsplat/symbol-upload',
-        content: 'symbol-upload contains a command line utility and set of libraries to help you upload symbols to BugSplat.',
+        content: 'symbol-upload contains a command line utility and a set of libraries to help you upload symbol files to BugSplat.',
     },
     {
         header: 'Usage',
         optionList: argDefinitions
     },
     {
-        content: 'The -u and -p arguments are optional if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD.'
+        content: 'The -u and -p arguments are not required if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD.'
     },
     {
         header: 'Example',

--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -1,0 +1,108 @@
+import { OptionDefinition as ArgDefinition } from "command-line-args";
+import { OptionDefinition as UsageDefinition, Section } from "command-line-usage";
+
+export type CommandLineDefinition = ArgDefinition & UsageDefinition;
+
+export const argDefinitions: Array<CommandLineDefinition> = [
+    {
+        name: 'help',
+        alias: 'h',
+        type: Boolean,
+        description: 'Print this usage guide.'
+    },
+    {
+        name: 'database',
+        alias: 'b',
+        type: String,
+        typeLabel: '{underline string}',
+        description: 'Your BugSplat database name.'
+    },
+    {
+        name: 'application',
+        alias: 'a',
+        type: String,
+        typeLabel: '{underline string}',
+        description: 'The name of your application used to post crash reports',
+    },
+    {
+        name: 'version',
+        alias: 'v',
+        type: String,
+        typeLabel: '{underline string}',
+        description: 'The version of your application used to post crash reports',
+    },
+    {
+        name: 'user',
+        alias: 'u',
+        type: String,
+        typeLabel: '{underline string} (optional)',
+        description: 'The email address of your BugSplat account. Can also be provided via the SYMBOL_UPLOAD_USER environment variable. If provided --password must also be provided.',
+    },
+    {
+        name: 'password',
+        alias: 'p',
+        type: String,
+        typeLabel: '{underline string} (optional)',
+        description: 'The password for your BugSplat account. Can also be provided via the SYMBOL_UPLOAD_PASSWORD environment variable. If provided --user must also be provided.',
+    },
+    {
+        name: 'clientId',
+        alias: 'i',
+        type: String,
+        typeLabel: '{underline string} (optional)',
+        description: 'An OAuth2 Client Credentials Client ID for the specified database. Can also be provided via the SYMBOL_UPLOAD_CLIENT_ID environment variable. If provided --clientSecret must also be provided.',
+    },
+    {
+        name: 'clientSecret',
+        alias: 's',
+        type: String,
+        typeLabel: '{underline string} (optional)',
+        description: 'An OAuth2 Client Credentials Client Secret for the specified database. Can also be provided via the SYMBOL_UPLOAD_CLIENT_SECRET environment variable. If provided --clientId must also be provided.',
+    },
+    {
+        name: 'remove',
+        alias: 'r',
+        type: Boolean,
+        description: 'Removes symbols for specified database, application, version, and exits.'
+    },
+    {
+        name: 'files',
+        alias: 'f',
+        type: String,
+        defaultValue: '*.js.map',
+        typeLabel: '{underline string} (optional)',
+        description: 'Glob pattern specifying a file pattern to upload. Defaults to \'*.js.map\'',
+    },
+    {
+        name: 'directory',
+        alias: 'd',
+        type: String,
+        defaultValue: '.',
+        typeLabel: '{underline string} (optional)',
+        description: 'Path to base directory to search for symbols and will be combined with the -f glob. Defaults to \'.\'',
+    }
+];
+
+export const usageDefinitions: Array<Section> = [
+    {
+        header: '@bugsplat/symbol-upload',
+        content: '@bugsplat/symbol-upload contains a command line utility and set of libraries to help you upload symbols to BugSplat.',
+    },
+    {
+        header: 'Usage',
+        content: 'symbol-upload -b {your-bugsplat-database} -a {your-application-name} -v {your-version} [ -f "*.js.map" -d "/path/to/containing/dir" [ -u {your-bugsplat-email} -p {your-bugsplat-password} ] OR [ -i {your-client-id} -s {your-client-secret} ] ]',
+        optionList: argDefinitions
+    },
+    {
+        content: 'The -u and -p arguments are optional if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD, or provide a Client ID and Client Secret pair.'
+    },
+    {
+        content: 'The -i and -s arguments are optional if you set the environment variables SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET, or provide a user and password.'
+    },
+    {
+        content: '{underline https://github.com/BugSplat-Git/symbol-upload}'
+    },
+    {
+        content: '❤️ support@bugsplat.com'
+    }
+];

--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -79,11 +79,12 @@ export const usageDefinitions: Array<Section> = [
         optionList: argDefinitions
     },
     {
+        content: 'The -u and -p arguments are optional if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD.'
+    },
+    {
         header: 'Example',
         content: [
             'symbol-upload -b {italic your-bugsplat-database} -a {italic your-application-name} -v {italic your-version} [ -f "*.js.map" -d "/path/to/containing/dir" -u {italic your-bugsplat-email} -p {italic your-bugsplat-password} ]',
-            '',
-            'The -u and -p arguments are optional if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD.'
         ]
     },
     {

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-import { ApiClient, BugSplatApiClient, OAuthClientCredentialsClient, SymbolsApiClient } from '@bugsplat/js-api-client';
+import { ApiClient, BugSplatApiClient, SymbolsApiClient } from '@bugsplat/js-api-client';
 import commandLineArgs from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
 import fs from 'fs';
@@ -14,8 +14,6 @@ let {
     version,
     user,
     password,
-    clientId,
-    clientSecret,
     remove,
     files,
     directory
@@ -39,15 +37,11 @@ if (!version) {
 
 user = user ?? process.env.SYMBOL_UPLOAD_USER;
 password = password ?? process.env.SYMBOL_UPLOAD_PASSWORD;
-clientId = clientId ?? process.env.SYMBOL_UPLOAD_CLIENT_ID;
-clientSecret = clientSecret ?? process.env.SYMBOL_UPLOAD_CLIENT_SECRET;
 
 if (
     !validAuthenticationArguments({
         user,
-        password,
-        clientId,
-        clientSecret
+        password
     })
 ) {
     logMissingAuthAndExit();
@@ -59,9 +53,7 @@ if (
 
     const bugsplat = await createBugSplatClient({
         user,
-        password,
-        clientId,
-        clientSecret
+        password
     });
 
     console.log('Authentication success!');
@@ -127,19 +119,9 @@ if (
 
 async function createBugSplatClient({
     user,
-    password,
-    clientId,
-    clientSecret
+    password
 }: AuthenticationArgs): Promise<ApiClient> {
-    let client;
-
-    if (user && password) {
-        client = await BugSplatApiClient.createAuthenticatedClientForNode(user, password);
-    } else {
-        client = await OAuthClientCredentialsClient.createAuthenticatedClient(clientId, clientSecret);
-    }
-
-    return client;
+    return BugSplatApiClient.createAuthenticatedClientForNode(user, password);
 }
 
 function logHelpAndExit() {
@@ -154,22 +136,18 @@ function logMissingArgAndExit(arg: string): void {
 }
 
 function logMissingAuthAndExit(): void {
-    console.log('\nInvalid authentication arguments: please provide either a user and password, or a clientId and clientSecret\n');
+    console.log('\nInvalid authentication arguments: please provide a user and password\n');
     process.exit(1);
 }
 
 function validAuthenticationArguments({
     user,
-    password,
-    clientId,
-    clientSecret
+    password
 }: AuthenticationArgs): boolean {
-    return !!(user && password) || !!(clientId && clientSecret);
+    return !!(user && password);
 }
 
 interface AuthenticationArgs {
     user: string,
-    password: string,
-    clientId: string,
-    clientSecret: string
+    password: string
 }

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -1,62 +1,77 @@
 #! /usr/bin/env node
-import { BugSplatApiClient, SymbolsApiClient } from '@bugsplat/js-api-client';
+import { ApiClient, BugSplatApiClient, OAuthClientCredentialsClient, SymbolsApiClient } from '@bugsplat/js-api-client';
+import commandLineArgs from 'command-line-args';
+import commandLineUsage from 'command-line-usage';
 import fs from 'fs';
 import glob from 'glob-promise';
 import { basename } from 'path';
+import { argDefinitions, usageDefinitions } from './command-line-definitions';
+
+let {
+    help,
+    database,
+    application,
+    version,
+    user,
+    password,
+    clientId,
+    clientSecret,
+    remove,
+    files,
+    directory
+} = commandLineArgs(argDefinitions);
+
+if (help) {
+    logHelpAndExit();    
+}
+
+if (!database) {
+    logMissingArgAndExit('database');
+}
+
+if (!application) {
+    logMissingArgAndExit('application');
+}
+
+if (!version) {
+    logMissingArgAndExit('version');
+}
+
+user = user ?? process.env.SYMBOL_UPLOAD_USER;
+password = password ?? process.env.SYMBOL_UPLOAD_PASSWORD;
+clientId = clientId ?? process.env.SYMBOL_UPLOAD_CLIENT_ID;
+clientSecret = clientSecret ?? process.env.SYMBOL_UPLOAD_CLIENT_SECRET;
+
+if (
+    !validAuthenticationArguments({
+        user,
+        password,
+        clientId,
+        clientSecret
+    })
+) {
+    logMissingAuthAndExit();
+}
 
 (async () => {
-    if (
-        process.argv.some(arg => arg === '-h')
-        || process.argv.some(arg => arg === '/h')
-        || process.argv.some(arg => arg === '-help')
-        || process.argv.some(arg => arg === '/help')
-        || process.argv.length <= 1
-    ) {
-        helpAndExit();
-    }
 
-    const databaseFlag = <string>process.argv.find(arg => arg === '-database');
-    if (!databaseFlag) {
-        missingArg('database');
-    }
+    console.log('About to authenticate...')
 
-    const applicationFlag = <string>process.argv.find(arg => arg === '-application');
-    if (!applicationFlag) {
-        missingArg('application');
-    }
+    const bugsplat = await createBugSplatClient({
+        user,
+        password,
+        clientId,
+        clientSecret
+    });
 
-    const versionFlag = <string>process.argv.find(arg => arg === '-version');
-    if (!versionFlag) {
-        missingArg('version');
-    }
+    console.log('Authentication success!');
 
-    const emailFlag = <string>process.argv.find(arg => arg === '-email');
-    const email = emailFlag ? process.argv[process.argv.indexOf(emailFlag) + 1] : <string>process.env.SYMBOL_UPLOAD_EMAIL;
-    if (!email) {
-        missingArg('email');
-    }
+    const symbolsApiClient = new SymbolsApiClient(bugsplat);
 
-    const passwordFlag = <string>process.argv.find(arg => arg === '-password');
-    const password = passwordFlag ? process.argv[process.argv.indexOf(passwordFlag) + 1] : <string>process.env.SYMBOL_UPLOAD_PASSWORD;
-    if (!password) {
-        missingArg('password');
-    }
-
-    const database = process.argv[process.argv.indexOf(databaseFlag) + 1];
-    const application = process.argv[process.argv.indexOf(applicationFlag) + 1];
-    const version = process.argv[process.argv.indexOf(versionFlag) + 1];
-
-    const deleteFlag = <string>process.argv.find(arg => arg === '-delete');
-    if (deleteFlag) {
+    if (remove) {
         try {
-            console.log(`About to log into BugSplat with user ${email}...`);
-    
-            const bugsplat = await BugSplatApiClient.createAuthenticatedClientForNode(email, password);
-    
-            console.log('Login successful!');
             console.log(`About to delete symbols for ${database}-${application}-${version}...`);
 
-            const symbolsApiClient = new SymbolsApiClient(bugsplat);
             await symbolsApiClient.deleteSymbols(
                 database,
                 application,
@@ -72,10 +87,6 @@ import { basename } from 'path';
         }
     }
 
-    const filesFlag = <string>process.argv.find(arg => arg === '-files');
-    const directoryFlag = <string>process.argv.find(arg => arg === '-directory');
-    const files = process.argv.indexOf(filesFlag) >= 0 ? process.argv[process.argv.indexOf(filesFlag) + 1] : '*.js.map';
-    const directory = process.argv.indexOf(directoryFlag) >= 0 ? process.argv[process.argv.indexOf(directoryFlag) + 1] : '.';
     const globPattern = `${directory}/${files}`;
 
     try {
@@ -86,11 +97,6 @@ import { basename } from 'path';
         }
 
         console.log(`Found files:\n ${paths}`);
-        console.log(`About to log into BugSplat with user ${email}...`);
-
-        const bugsplat = await BugSplatApiClient.createAuthenticatedClientForNode(email, password);
-
-        console.log('Login successful!');
         console.log(`About to upload symbols for ${database}-${application}-${version}...`);
 
         const files = paths.map(path => {
@@ -105,7 +111,6 @@ import { basename } from 'path';
             };
         });
 
-        const symbolsApiClient = new SymbolsApiClient(bugsplat);
         await symbolsApiClient.postSymbols(
             database,
             application,
@@ -120,25 +125,51 @@ import { basename } from 'path';
     }
 })();
 
-function helpAndExit() {
-    const help = '\n'
-        + '@bugsplat/symbol-upload contains a command line utility and set of libraries to help you upload symbols to BugSplat.'
-        + '\n\n\n'
-        + 'symbol-upload command line usage:'
-        + '\n\n\n'
-        + '\tsymbol-upload -database {your-bugsplat-database} -application {your-application-name} -version {your-version} [ -email {your-email-login} -password {your-password} -files "*.js.map" -directory "/path/to/containing/dir" ]'
-        + '\n\n\n'
-        + 'The -email and -password arguments are optional if you set the environment variables SYMBOL_UPLOAD_EMAIL and SYMBOL_UPLOAD_PASSWORD respectively. '
-        + '\n\n'
-        + 'The -files and -directory arguments are optional and will default to "*.js.map" and "." respectively.'
-        + '\n\n\n'
-        + '❤️ support@bugsplat.com';
+async function createBugSplatClient({
+    user,
+    password,
+    clientId,
+    clientSecret
+}: AuthenticationArgs): Promise<ApiClient> {
+    let client;
 
+    if (user && password) {
+        client = await BugSplatApiClient.createAuthenticatedClientForNode(user, password);
+    } else {
+        client = await OAuthClientCredentialsClient.createAuthenticatedClient(clientId, clientSecret);
+    }
+
+    return client;
+}
+
+function logHelpAndExit() {
+    const help = commandLineUsage(usageDefinitions);
     console.log(help);
     process.exit(1);
 }
 
-function missingArg(arg: string) {
+function logMissingArgAndExit(arg: string): void {
     console.log(`\nMissing argument: -${arg}\n`);
     process.exit(1);
+}
+
+function logMissingAuthAndExit(): void {
+    console.log('\nInvalid authentication arguments: please provide either a user and password, or a clientId and clientSecret\n');
+    process.exit(1);
+}
+
+function validAuthenticationArguments({
+    user,
+    password,
+    clientId,
+    clientSecret
+}: AuthenticationArgs): boolean {
+    return !!(user && password) || !!(clientId && clientSecret);
+}
+
+interface AuthenticationArgs {
+    user: string,
+    password: string,
+    clientId: string,
+    clientSecret: string
 }

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,6 @@
-export { BugSplatApiClient, SymbolsApiClient } from '@bugsplat/js-api-client';
+export {
+    BugSplatApiClient,
+    SymbolsApiClient,
+    OAuthClientCredentialsClient,
+    UploadableFile
+} from '@bugsplat/js-api-client';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "@bugsplat/js-api-client": "^1.0.3",
+        "@bugsplat/js-api-client": "^1.1.0",
+        "command-line-args": "^5.2.0",
+        "command-line-usage": "^6.1.1",
         "form-data": "^4.0.0",
         "glob": "^7.1.6",
         "glob-promise": "^4.2.0",
@@ -20,6 +22,8 @@
         "symbol-upload": "dist/bin/index.js"
       },
       "devDependencies": {
+        "@types/command-line-args": "^5.2.0",
+        "@types/command-line-usage": "^5.0.2",
         "@types/glob": "^7.1.3",
         "@types/node": "^14.14.37",
         "ts-node": "^10.2.1",
@@ -27,9 +31,9 @@
       }
     },
     "node_modules/@bugsplat/js-api-client": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@bugsplat/js-api-client/-/js-api-client-1.0.3.tgz",
-      "integrity": "sha512-OQli4EhLG9qnwCwjnoPWYVKjK9X2OZ9iuQrd64Q+MwA3RL+I52PB4e0v2R4ST1cAvyXNH/0qyYk+lBZ6IPxHRw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@bugsplat/js-api-client/-/js-api-client-1.1.0.tgz",
+      "integrity": "sha512-6MYmdabBoZ9Gq8pDfhmJ4FNAmDFlj/mTgrKs/6xrn5DC3SEYb+QUyCfSrawzALqa0E7AbxVm9uHqELmjgmKD2Q==",
       "dependencies": {
         "argument-contracts": "^1.2.3",
         "fetch-ponyfill": "^7.1.0",
@@ -101,6 +105,18 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-UuKzKpJJ/Ief6ufIaIzr3A/0XnluX7RvFgwkV89Yzvm77wCh1kFaFmqN8XEnGcN62EuHdedQjEMb8mYxFLGPyA==",
+      "dev": true
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.2.tgz",
+      "integrity": "sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg==",
+      "dev": true
+    },
     "node_modules/@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -141,6 +157,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -153,6 +180,14 @@
       "integrity": "sha512-Gh3Z4dAp+L/MNT9jQb9ClCOnb1qmwzGRcIeKWpHKi4iVFzdpLsX3b9A2qacw7sahPHRtw+hRdFQZbRvrOqCVsA==",
       "dependencies": {
         "@meltwater/coerce": "0.2.1"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/asynckit": {
@@ -174,6 +209,32 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -183,6 +244,50 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.1",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/concat-map": {
@@ -195,6 +300,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -213,12 +326,31 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fetch-ponyfill": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-7.1.0.tgz",
       "integrity": "sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==",
       "dependencies": {
         "node-fetch": "~2.6.1"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/form-data": {
@@ -276,6 +408,14 @@
         "glob": "^7.1.6"
       }
     },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -289,6 +429,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -350,6 +495,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/rxjs": {
       "version": "6.6.6",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
@@ -359,6 +512,47 @@
       },
       "engines": {
         "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ts-node": {
@@ -423,6 +617,34 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -440,9 +662,9 @@
   },
   "dependencies": {
     "@bugsplat/js-api-client": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@bugsplat/js-api-client/-/js-api-client-1.0.3.tgz",
-      "integrity": "sha512-OQli4EhLG9qnwCwjnoPWYVKjK9X2OZ9iuQrd64Q+MwA3RL+I52PB4e0v2R4ST1cAvyXNH/0qyYk+lBZ6IPxHRw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@bugsplat/js-api-client/-/js-api-client-1.1.0.tgz",
+      "integrity": "sha512-6MYmdabBoZ9Gq8pDfhmJ4FNAmDFlj/mTgrKs/6xrn5DC3SEYb+QUyCfSrawzALqa0E7AbxVm9uHqELmjgmKD2Q==",
       "requires": {
         "argument-contracts": "^1.2.3",
         "fetch-ponyfill": "^7.1.0",
@@ -510,6 +732,18 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/command-line-args": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-UuKzKpJJ/Ief6ufIaIzr3A/0XnluX7RvFgwkV89Yzvm77wCh1kFaFmqN8XEnGcN62EuHdedQjEMb8mYxFLGPyA==",
+      "dev": true
+    },
+    "@types/command-line-usage": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.2.tgz",
+      "integrity": "sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -541,6 +775,14 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -554,6 +796,11 @@
       "requires": {
         "@meltwater/coerce": "0.2.1"
       }
+    },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -574,12 +821,69 @@
         "concat-map": "0.0.1"
       }
     },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
+      }
+    },
+    "command-line-args": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
+      "requires": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.1",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
       }
     },
     "concat-map": {
@@ -593,6 +897,11 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -604,12 +913,25 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
     "fetch-ponyfill": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-7.1.0.tgz",
       "integrity": "sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==",
       "requires": {
         "node-fetch": "~2.6.1"
+      }
+    },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
       }
     },
     "form-data": {
@@ -648,6 +970,11 @@
         "@types/glob": "^7.1.3"
       }
     },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -661,6 +988,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "make-error": {
       "version": "1.3.6",
@@ -707,12 +1039,48 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
+    },
     "rxjs": {
       "version": "6.6.6",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
       "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
       "requires": {
         "tslib": "^1.9.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
       }
     },
     "ts-node": {
@@ -745,6 +1113,27 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
       "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
       "dev": true
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+    },
+    "wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -33,13 +33,17 @@
   },
   "homepage": "https://github.com/BugSplat-Git/symbol-upload#readme",
   "devDependencies": {
+    "@types/command-line-args": "^5.2.0",
+    "@types/command-line-usage": "^5.0.2",
     "@types/glob": "^7.1.3",
     "@types/node": "^14.14.37",
     "ts-node": "^10.2.1",
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "@bugsplat/js-api-client": "^1.0.3",
+    "@bugsplat/js-api-client": "^1.1.0",
+    "command-line-args": "^5.2.0",
+    "command-line-usage": "^6.1.1",
     "form-data": "^4.0.0",
     "glob": "^7.1.6",
     "glob-promise": "^4.2.0",


### PR DESCRIPTION
Uses [command-line-usage](https://www.npmjs.com/package/command-line-usage) and [command-line-args](https://www.npmjs.com/package/command-line-args) to standardize the parsing of our command-line arguments and print a standardized help message.

```
PS /Users/bobby/Desktop/bugsplat/symbol-upload> node ./dist/bin/index.js -h


@bugsplat/symbol-upload

  symbol-upload contains a command line utility and set of libraries to help    
  you upload symbols to BugSplat.                                               

Usage

  -h, --help                          Print this usage guide.                                                       
  -b, --database string               Your BugSplat database name.                                                  
  -a, --application string            The name of your application used to post crash reports                       
  -v, --version string                The version of your application used to post crash reports                    
  -u, --user string (optional)        The email address of your BugSplat account. Can also be provided via the      
                                      SYMBOL_UPLOAD_USER environment variable. If provided --password must also be  
                                      provided.                                                                     
  -p, --password string (optional)    The password for your BugSplat account. Can also be provided via the          
                                      SYMBOL_UPLOAD_PASSWORD environment variable. If provided --user must also be  
                                      provided.                                                                     
  -r, --remove                        Removes symbols for specified database, application, version, and exits.      
  -f, --files string (optional)       Glob pattern specifying a file pattern to upload. Defaults to '*.js.map'      
  -d, --directory string (optional)   Path to base directory to search for symbols and will be combined with the -f 
                                      glob. Defaults to '.'                                                         

  The -u and -p arguments are optional if you set the environment variables     
  SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD.     

Example

  symbol-upload -b _your-bugsplat-database_ -a _your-application-name_ -v _your-     
  version_ [ -f "*.js.map" -d "/path/to/containing/dir" -u _your-bugsplat-email_   
  -p _your-bugsplat-password_ ]                                                   
                                                                                                           

Links

  🐛 https://bugsplat.com                          
                                                   
  💻 https://github.com/BugSplat-Git/symbol-upload 
                                                   
  💌 support@bugsplat.com    
```

Fixes #28