### PR TITLE
fix: use correct temp dir

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -129,11 +129,12 @@ import { createWorkersFromSymbolFiles } from './worker';
                 const timestamp = Math.round(new Date().getTime() / 1000);   
 
                 const isSymFile = extname(symbolFilePath).toLowerCase().includes('.sym');
-                let tmpZipName = join(__dirname, 'tmp', `${fileName}-${timestamp}.zip`);
+                const currentDirectory = process ? process.cwd() : __dirname;
+                let tmpZipName = join(currentDirectory, 'tmp', `${fileName}-${timestamp}.zip`);
                 
                 if (isSymFile) {
                     const debugId = await getSymFileDebugId(symbolFilePath);
-                    tmpZipName = `${fileName}-${debugId}-${timestamp}-bsv1.zip`;
+                    tmpZipName = join(currentDirectory, 'tmp', `${fileName}-${debugId}-${timestamp}-bsv1.zip`);
                 }
 
                 console.log(`Zipping file ${tmpZipName}...`);


### PR DESCRIPTION
When we package up our node app, the way you find the current working directory is different:


| value                         | with `node`     | packaged                 | comments                       |
| ----------------------------- | --------------- | ------------------------ | ------------------------------ |
| \_\_filename                  | /project/app.js | /snapshot/project/app.js |
| \_\_dirname                   | /project        | /snapshot/project        |
| process.cwd()                 | /project        | /deploy                  | suppose the app is called ...  |
| process.execPath              | /usr/bin/nodejs | /deploy/app-x64          | `app-x64` and run in `/deploy` |
| process.argv[0]               | /usr/bin/nodejs | /deploy/app-x64          |
| process.argv[1]               | /project/app.js | /snapshot/project/app.js |
| process.pkg.entrypoint        | undefined       | /snapshot/project/app.js |
| process.pkg.defaultEntrypoint | undefined       | /snapshot/project/app.js |
| require.main.filename         | /project/app.js | /snapshot/project/app.js |

source: https://github.com/vercel/pkg#snapshot-filesystem

that change just prefers process.cwd() over __dirname which i found out by referencing that chart in pkg