### PR TITLE
fix: error ENOTEMPTY deleting tmp

### DIFF
--- a/bin/symbol-file-info.ts
+++ b/bin/symbol-file-info.ts
@@ -1,0 +1,3 @@
+import { SymbolFile } from '@bugsplat/js-api-client';
+
+export type SymbolFileInfo = Omit<SymbolFile, 'file'> & { file: string };

--- a/bin/tmp.ts
+++ b/bin/tmp.ts
@@ -1,0 +1,23 @@
+import { rm } from 'fs/promises';
+import { join } from 'path';
+import promiseRetry from 'promise-retry';
+
+const currentDirectory = process ? process.cwd() : __dirname;
+
+export const tmpDir = join(currentDirectory, 'tmp');
+
+export async function safeRemoveTmp(remover = rm): Promise<void> {
+    try {
+        await promiseRetry(
+            (retry) => remover(tmpDir, { recursive: true, force: true }).catch(retry),
+            {
+                minTimeout: 0, // First retry immediately
+                maxTimeout: 2000, // Subsequent retries delay by 2 seconds
+                factor: 2, // Exponential backoff
+                retries: 4, // Try 4 times
+            }
+        );
+    } catch (error) {
+        console.error(`Could not delete ${tmpDir}!`, error);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "glob": "^8.0.3",
         "glob-promise": "^5.0.0",
         "pdb-guid": "^1.0.5",
-        "rxjs": "^6.6.6"
+        "promise-retry": "^2.0.1",
+        "rxjs": "^7.8.1"
       },
       "bin": {
         "symbol-upload": "dist/bin/index.js"
@@ -30,6 +31,7 @@
         "@types/glob": "^7.1.3",
         "@types/jasmine": "^4.3.1",
         "@types/node": "^18.15.10",
+        "@types/promise-retry": "^1.1.4",
         "dotenv": "^10.0.0",
         "jasmine": "^4.6.0",
         "pkg": "^5.8.1",
@@ -127,19 +129,6 @@
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/@bugsplat/js-api-client/node_modules/rxjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
-      "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
-      "dependencies": {
-        "tslib": "~2.1.0"
-      }
-    },
-    "node_modules/@bugsplat/js-api-client/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "node_modules/@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -435,6 +424,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.10.tgz",
       "integrity": "sha512-9avDaQJczATcXgfmMAW3MIWArOO7A+m90vuCFLr8AotWf8igO/mRoYukrk2cqZVtv38tHs33retzHEilM7FpeQ=="
     },
+    "node_modules/@types/promise-retry": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.4.tgz",
+      "integrity": "sha512-DmJeCIhfpAE0XonyVUa0BRLbkE/97L9KUO8iM2br8Bzl8GLuru842K1A8VgKJwNjtLvIbUnSqElhNKdM9mGl9w==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/readdir-glob": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.1.tgz",
@@ -443,6 +441,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.3.tgz",
+      "integrity": "sha512-rkxEZUFIyDEZhC6EfHz6Hwos2zXewCOLBzhdgv7D55qu4OAySNwDZzxbaMpFI6XthdBa5oHhR5s6/9MSuTfw4g==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.5.0",
@@ -1085,6 +1089,11 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -2186,6 +2195,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2287,6 +2308,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -2376,14 +2405,11 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-      "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -2746,9 +2772,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3096,21 +3122,6 @@
       "requires": {
         "argument-contracts": "^1.2.3",
         "rxjs": "^7.1.0"
-      },
-      "dependencies": {
-        "rxjs": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
-          "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
-          "requires": {
-            "tslib": "~2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-        }
       }
     },
     "@cspotcode/source-map-consumer": {
@@ -3349,6 +3360,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.10.tgz",
       "integrity": "sha512-9avDaQJczATcXgfmMAW3MIWArOO7A+m90vuCFLr8AotWf8igO/mRoYukrk2cqZVtv38tHs33retzHEilM7FpeQ=="
     },
+    "@types/promise-retry": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.4.tgz",
+      "integrity": "sha512-DmJeCIhfpAE0XonyVUa0BRLbkE/97L9KUO8iM2br8Bzl8GLuru842K1A8VgKJwNjtLvIbUnSqElhNKdM9mGl9w==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
+      }
+    },
     "@types/readdir-glob": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.1.tgz",
@@ -3357,6 +3377,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/retry": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.3.tgz",
+      "integrity": "sha512-rkxEZUFIyDEZhC6EfHz6Hwos2zXewCOLBzhdgv7D55qu4OAySNwDZzxbaMpFI6XthdBa5oHhR5s6/9MSuTfw4g==",
+      "dev": true
     },
     "acorn": {
       "version": "8.5.0",
@@ -3839,6 +3865,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -4645,6 +4676,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "requires": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      }
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -4717,6 +4757,11 @@
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -4766,11 +4811,11 @@
       }
     },
     "rxjs": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-      "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {
@@ -5014,9 +5059,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/glob": "^7.1.3",
     "@types/jasmine": "^4.3.1",
     "@types/node": "^18.15.10",
+    "@types/promise-retry": "^1.1.4",
     "dotenv": "^10.0.0",
     "jasmine": "^4.6.0",
     "pkg": "^5.8.1",
@@ -65,6 +66,7 @@
     "glob": "^8.0.3",
     "glob-promise": "^5.0.0",
     "pdb-guid": "^1.0.5",
-    "rxjs": "^6.6.6"
+    "promise-retry": "^2.0.1",
+    "rxjs": "^7.8.1"
   }
 }

--- a/spec/tmp.spec.ts
+++ b/spec/tmp.spec.ts
@@ -1,0 +1,17 @@
+import { safeRemoveTmp } from '../bin/tmp';
+
+describe('tmp', () => {
+    it('should retry removing tmp directory', async () => {
+        let retried = false;
+        const remover = jasmine.createSpy('remover').and.callFake(async () => {
+            if (!retried) {
+                retried = true;
+                throw new Error('Failed to remove tmp directory!');
+            }
+        });
+
+        await safeRemoveTmp(remover);
+
+        expect(remover).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
We know that the Windows file system can be super sus and hang on to files. This change does the following:

* Ensures that we release the handle on tmpZipFile when there's an error
* Retries deleting the tmp directory with an exponential backoff

Fixes #60