### PR TITLE
fix: source map uploads

### DIFF
--- a/spec/worker.spec.ts
+++ b/spec/worker.spec.ts
@@ -68,7 +68,7 @@ describe('worker', () => {
 
             it('should call versionsClient.postSymbols with database, application, version, and symbol files', () => {
                 const symbolFiles = symbolFileInfos.map(symbolFile => ({
-                    name: symbolFile.path,
+                    name: `${symbolFile.path}.zip`,
                     dbgId: symbolFile.dbgId,
                     moduleName: symbolFile.moduleName,
                     size: 0,


### PR DESCRIPTION
Now that we're not using the bsv1 protocol we need to instruct the backend that this is a zip file.

Fixes #82