### PR TITLE
chore: add GitHub action blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 # symbol-upload
 
-This is a simple Node.js utility and set of libraries for uploading symbol files or source maps to [BugSplat](https://www.bugsplat.com). This utility is designed to be used in your build process to upload symbols to BugSplat for each production build automatically. This package can be used as a library or a command line utility.
+This repo is a simple Node.js utility, set of libraries, and GitHub action for uploading symbol files or source maps to [BugSplat](https://www.bugsplat.com). This utility is designed to be used in your build process to upload symbols to BugSplat for each production build automatically. This package can be used as a library or a command line utility.
 
 ## Action
 


### PR DESCRIPTION
### Description

Make it clear the GitHub action uploads symbols to BugSplat

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
