### PR TITLE
chore: update action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,7 @@ runs:
   steps:
     - name: Install symbol-upload
       shell: bash
-      run: npm i -g @bugsplat/symbol-upload
+      run: npm i -g @bugsplat/symbol-upload@7.2.3
         
     - name: Run symbol-upload
       shell: bash


### PR DESCRIPTION
### Description

Bind to 7.2.3 directly for a bit so that CI machines that have the faulty 7.2.2 version installed are updated to a working version.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
