### PR TITLE
fix: temporary directory for .gz files

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,7 +1,7 @@
 import { SymbolsApiClient, VersionsApiClient } from '@bugsplat/js-api-client';
-import { ReadStream, createReadStream } from 'fs';
+import { ReadStream, createReadStream, existsSync, mkdirSync } from 'fs';
 import { stat } from 'node:fs/promises';
-import { basename, extname, join } from 'node:path';
+import { basename, dirname, extname, join } from 'node:path';
 import retryPromise from 'promise-retry';
 import { WorkerPool, cpus } from 'workerpool';
 import { SymbolFileInfo } from './info';
@@ -56,6 +56,10 @@ export class UploadWorker {
 
         if (dbgId && !isZip) {
             tmpFileName = join(tmpDir, `${fileName}.gz`);
+            let tmpSubdir = join(tmpDir, dirname(fileName));
+            if (!existsSync(tmpSubdir)) {
+                mkdirSync(tmpSubdir, { recursive: true });
+            }
             client = this.symbolsClient;
             await this.pool.exec('createGzipFile', [path, tmpFileName]);
         } else if (!isZip) {


### PR DESCRIPTION
### Description

See #98.
Not sure about other use-cases, but on Linux when trying to upload a .sym file, symbol-upload tries to write into a temporary subdirectory which doesn't exist and therefore the upload fails.

This is a straightforward fix.

Fixes #98.

Feel free to implement this in another way if this does not capture the intent. If any unit tests/documentation if needed I'd rather leave that up to you.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
