### PR TITLE
fix: make action standalone

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,24 @@
+name: Test My GitHub Action
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-my-action:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Symbols 📦
+      uses: ./
+      with:
+        clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
+        clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
+        database: "${{ secrets.BUGSPLAT_DATABASE }}"
+        application: "symbol-upload-test"
+        version: "1.0"
+        directory: "spec/support"
+        files: "**/*.sym"
+        node-version: '21'

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ You can use the `symbol-upload` action in your [GitHub Actions](https://github.c
     with:
       clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
       clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
-      database:"${{ secrets.BUGSPLAT_DATABASE }}"
+      database: "${{ secrets.BUGSPLAT_DATABASE }}"
       application: "your-application"
       version: "your-version"
       files: "**/*.{pdb,exe,dll}"
       directory: "your-build-directory"
+      node-version: "20"
 ```
 
 Be sure to use [secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) so that you don't expose the values for `clientId`, `clientSecret`, and `database`.

--- a/action.yaml
+++ b/action.yaml
@@ -44,10 +44,20 @@ inputs:
     description: "Base directory for files"
     type: string
     required: false
+  node-version:
+    description: "Node.js version to use"
+    type: string
+    required: false
+    default: '20'
 
 runs:
   using: composite
   steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
     - name: Install symbol-upload
       shell: bash
       run: npm i -g @bugsplat/symbol-upload

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "prerelease": "npm run build",
     "release": "npm publish --access public",
     "prepkg": "npm run build",
-    "pkg": "npx pkg package.json"
+    "pkg": "npx pkg package.json",
+    "act": "act --secret-file .env"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We had initially taken out the setup-node step in fear that it might interfere with the setup-node step of the calling action. This doesn't appear to be an issue after all.

Additionally, by including a setup-node step, the calling action doesn't have to worry about calling setup-node, which is a better solution for actions that otherwise wouldn't use node.

Finally, for actions already using node, we expose a `node-version` input so that the calling action can dictate which version of node symbol-upload uses.

Fixes #97