### PR TITLE
fix: elf guids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.4.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsplat/elfy": "^1.0.0",
+        "@bugsplat/elfy": "^1.0.1",
         "@bugsplat/js-api-client": "^8.0.1",
         "archiver": "^5.3.1",
         "command-line-args": "^5.2.0",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@bugsplat/elfy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bugsplat/elfy/-/elfy-1.0.0.tgz",
-      "integrity": "sha512-gVNfYzyhq1Ryc7SeYmVLTRefj/awo4ISqkRqbgTZVTQSWGsU4IHyUURqkzAwZp98q/u6kGLW1XaYmxaf36VT/A=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bugsplat/elfy/-/elfy-1.0.1.tgz",
+      "integrity": "sha512-XIxg2iY/1Ype+LuVs1NvFo+k/nqQrgeJlrnfMjm+DfuzGj+siFJF0/3XvUKjmPWdLNNd/Sik8KsPi4KcLHiGBA=="
     },
     "node_modules/@bugsplat/js-api-client": {
       "version": "8.0.1",
@@ -3378,9 +3378,9 @@
       }
     },
     "@bugsplat/elfy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bugsplat/elfy/-/elfy-1.0.0.tgz",
-      "integrity": "sha512-gVNfYzyhq1Ryc7SeYmVLTRefj/awo4ISqkRqbgTZVTQSWGsU4IHyUURqkzAwZp98q/u6kGLW1XaYmxaf36VT/A=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bugsplat/elfy/-/elfy-1.0.1.tgz",
+      "integrity": "sha512-XIxg2iY/1Ype+LuVs1NvFo+k/nqQrgeJlrnfMjm+DfuzGj+siFJF0/3XvUKjmPWdLNNd/Sik8KsPi4KcLHiGBA=="
     },
     "@bugsplat/js-api-client": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@bugsplat/elfy": "^1.0.0",
+    "@bugsplat/elfy": "^1.0.1",
     "@bugsplat/js-api-client": "^8.0.1",
     "archiver": "^5.3.1",
     "command-line-args": "^5.2.0",

--- a/spec/dsym.spec.ts
+++ b/spec/dsym.spec.ts
@@ -9,14 +9,14 @@ describe('dsym', () => {
         it('should return path, relativePath, dbgIds, module names for macho files', () => {
             return expectAsync(getDSymFileInfos('spec/support/bugsplat.app.dSYM')).toBeResolvedTo(jasmine.arrayContaining([
                 {
-                    path: jasmine.stringMatching('/tmp/2dd1bd2706fa384da5a3a8265921cf9a/BugsplatTester'),
-                    relativePath: '2dd1bd2706fa384da5a3a8265921cf9a/BugsplatTester',
+                    path: jasmine.stringMatching(/tmp[\/\\]2dd1bd2706fa384da5a3a8265921cf9a[\/\\]BugsplatTester/),
+                    relativePath: jasmine.stringMatching(/2dd1bd2706fa384da5a3a8265921cf9a[\/\\]BugsplatTester/),
                     dbgId: '2dd1bd2706fa384da5a3a8265921cf9a',
                     moduleName: 'BugsplatTester',
                 },
                 {
-                    path: jasmine.stringMatching('/tmp/2ce192f6c5963e66b06aa22bde5756a0/BugsplatTester'),
-                    relativePath: '2ce192f6c5963e66b06aa22bde5756a0/BugsplatTester',
+                    path: jasmine.stringMatching(/tmp[\/\\]2ce192f6c5963e66b06aa22bde5756a0[\/\\]BugsplatTester/),
+                    relativePath: jasmine.stringMatching(/2ce192f6c5963e66b06aa22bde5756a0[\/\\]BugsplatTester/),
                     dbgId: '2ce192f6c5963e66b06aa22bde5756a0',
                     moduleName: 'BugsplatTester',
                 }

--- a/spec/elf.spec.ts
+++ b/spec/elf.spec.ts
@@ -3,7 +3,7 @@ import { tryGetElfUUID } from "../src/elf";
 describe('elf', () => {
     describe('tryGetElfUUID', () => {
         it('should return uuid for elf file', async () => {
-            return expectAsync(tryGetElfUUID('spec/support/bugsplat.elf')).toBeResolvedTo('005f5f676d6f6e5f73746172745f5f006c696263');
+            return expectAsync(tryGetElfUUID('spec/support/bugsplat.elf')).toBeResolvedTo('85fe216fc7dd441f04c237310a56081fbf23c082');
         });
     });
 });

--- a/src/elf.ts
+++ b/src/elf.ts
@@ -12,7 +12,7 @@ export async function tryGetElfUUID(path: string) {
   }
 
   if (success) {
-    return getUUID(section!);
+    return getUUID(section!, 16);
   }
 
   elfFile = await ElfFile.create(path);
@@ -29,6 +29,6 @@ export async function tryGetElfUUID(path: string) {
   return '';
 }
 
-function getUUID(section: Buffer) {
-  return section.subarray(0, 20).toString('hex');
+function getUUID(section: Buffer, offset = 0) {
+  return section.subarray(offset, offset + 20).toString('hex');
 }


### PR DESCRIPTION
### Description

Elfy updated to v1.0.1 which includes fix for parsing ELF strings table in correct order. Adds offset to the `.note.gnu.build-id` bytes we use for the UUID since that's how readelf seems to work.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
