### PR TITLE
feat: add dump_syms

### DIFF
--- a/.github/workflows/pkg.yaml
+++ b/.github/workflows/pkg.yaml
@@ -16,7 +16,7 @@ jobs:
             run_script: pkg:macos
             artifact_name: symbol-upload-macos
           - os: windows-latest
-            run_script: pkg:win
+            run_script: pkg:windows
             artifact_name: symbol-upload-win
     
     steps:

--- a/.github/workflows/pkg.yaml
+++ b/.github/workflows/pkg.yaml
@@ -1,0 +1,39 @@
+name: Build and Upload Artifacts for Multiple OS
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            run_script: pkg:linux
+            artifact_name: symbol-upload-linux
+          - os: macos-latest
+            run_script: pkg:macos
+            artifact_name: symbol-upload-macos
+          - os: windows-latest
+            run_script: pkg:win
+            artifact_name: symbol-upload-win
+    
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run platform-specific script
+      run: npm run ${{ matrix.run_script }} # Executes the script based on the operating system
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.artifact_name }}
+        path: pkg/* # Uploads the artifact with a platform-specific name and path

--- a/.github/workflows/pkg.yaml
+++ b/.github/workflows/pkg.yaml
@@ -1,6 +1,10 @@
-name: Build and Upload Artifacts for Multiple OS
+name: Package Builds
 
-on: [push]
+on:
+    push:
+        tags:
+        - 'v*'
+
 
 jobs:
   build:
@@ -20,20 +24,22 @@ jobs:
             artifact_name: symbol-upload-win
     
     steps:
-    - uses: actions/checkout@v4
+    - name: ☑️ Checkout
+      uses: actions/checkout@v4
 
-    - name: Setup Node.js
+    - name: ⚙️ Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '18'
 
-    - name: Install dependencies
+    - name: 🏗️ Install Dependencies
       run: npm ci
 
-    - name: Run platform-specific script
+    - name: 📦 Run Pkg
       run: npm run ${{ matrix.run_script }} # Executes the script based on the operating system
 
-    - uses: actions/upload-artifact@v4
+    - name: ⬆️ Upload Artifacts
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.artifact_name }}
         path: pkg/* # Uploads the artifact with a platform-specific name and path

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-name: Test My GitHub Action
+name: Test GitHub Action
 
 on:
   pull_request:
@@ -8,10 +8,10 @@ jobs:
   test-my-action:
     runs-on: ubuntu-latest
     steps:
-    - name: Check out code
+    - name: ☑️ Checkout
       uses: actions/checkout@v3
 
-    - name: Symbols 📦
+    - name: 📦 Symbols
       uses: ./
       with:
         clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,6 +57,19 @@
             "type": "node"
         },
         {
+            "name": "Start: dump_syms",
+            "request": "launch",
+            "runtimeArgs": [
+                "run-script",
+                "start:dump_syms",
+            ],
+            "runtimeExecutable": "npm",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        {
             "name": "Test",
             "request": "launch",
             "runtimeArgs": [

--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -85,6 +85,14 @@ export const argDefinitions: Array<CommandLineDefinition> = [
         typeLabel: '{underline string} (optional)',
         description: 'Path of the base directory used to search for symbol files. This value will be combined with the --files glob. Defaults to \'.\'',
     },
+    {
+        name: 'dumpSyms',
+        alias: 'm',
+        type: Boolean,
+        defaultValue: false,
+        description: 'Use dump_syms to generate and upload sym files for specified binaries.',
+        typeLabel: '{underline boolean} (optional)',
+    }
 ];
 
 export const usageDefinitions: Array<Section> = [
@@ -134,7 +142,7 @@ function getPackageVersion(): string {
     }
 
     const packageJson = readFileSync(path, 'utf-8').toString();
-    
+
     try {
         return JSON.parse(packageJson).version;
     } catch {

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -117,8 +117,8 @@ import { CommandLineDefinition, argDefinitions, usageDefinitions } from './comma
                 nodeDumpSyms(file, symFile);
                 return symFile;
             });
-        } catch (error) {
-            console.log('node-dump-syms not found, skipping sym dumping...');
+        } catch (cause) {
+            throw new Error('Can\'t run dump_syms! Please ensure node-dump-syms is installed https://github.com/BugSplat-Git/node-dump-syms', { cause });
         }
     }
 

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -187,12 +187,12 @@ function logHelpAndExit() {
 
 function logMissingArgAndExit(arg: string): void {
     console.log(`\nMissing argument: -${arg}\n`);
-    process.exit(1);
+    logHelpAndExit()
 }
 
 function logMissingAuthAndExit(): void {
     console.log('\nInvalid authentication arguments: please provide either a user and password, or a clientId and clientSecret\n');
-    process.exit(1);
+    logHelpAndExit()
 }
 
 function normalizeDirectory(directory: string): string {

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -109,6 +109,7 @@ import { CommandLineDefinition, argDefinitions, usageDefinitions } from './comma
 
     if (dumpSyms) {
         try {
+            // @ts-ignore: Cannot find module
             const nodeDumpSyms = (await import('node-dump-syms')).dumpSyms;
             symbolFilePaths = symbolFilePaths.map(file => {
                 console.log(`Dumping syms for ${file}...`);

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -123,14 +123,13 @@ import { CommandLineDefinition, argDefinitions, usageDefinitions } from './comma
     }
 
     await uploadSymbolFiles(bugsplat, database, application, version, directory, symbolFilePaths);
-
-    process.exit(0);
-})().catch((error) => {
-    console.error(error.message);
-    process.exit(1);
-}).finally(async () => {
     await safeRemoveTmp();
-})
+    process.exit(0);
+})().catch(async (error) => {
+    console.error(error.message);
+    await safeRemoveTmp();
+    process.exit(1);
+});
 
 async function createBugSplatClient({
     user,

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,9 @@
         "rimraf": "^5.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
+      },
+      "optionalDependencies": {
+        "node-dump-syms": "^3.0.6"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -1996,6 +1999,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/node-dump-syms": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/node-dump-syms/-/node-dump-syms-3.0.6.tgz",
+      "integrity": "sha512-zdxWP7niMjGrPbNPpOQK9ENECa1z9E3K8y3YUuyXc04pgtCVYRDsyJz3EnR6AehxGORVGcpH/eYaUbn7OUWCHQ==",
+      "hasInstallScript": true,
+      "optional": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -4811,6 +4821,12 @@
       "requires": {
         "semver": "^7.3.5"
       }
+    },
+    "node-dump-syms": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/node-dump-syms/-/node-dump-syms-3.0.6.tgz",
+      "integrity": "sha512-zdxWP7niMjGrPbNPpOQK9ENECa1z9E3K8y3YUuyXc04pgtCVYRDsyJz3EnR6AehxGORVGcpH/eYaUbn7OUWCHQ==",
+      "optional": true
     },
     "node-fetch": {
       "version": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,12 @@
     "build": "tsc",
     "prerelease": "npm run build",
     "release": "npm publish --access public",
-    "prepkg": "npm run build",
-    "pkg": "npx pkg package.json",
+    "prepkg:linux": "npm run build",
+    "pkg:linux": "npx pkg package.json --targets node18-linux-x64 --output ./pkg/symbol-upload-linux",
+    "prepkg:macos": "npm run build",
+    "pkg:macos": "npx pkg package.json --targets node18-macos-x64 --output ./pkg/symbol-upload-macos",
+    "prepkg:windows": "npm run build",
+    "pkg:windows": "npx pkg package.json --targets node18-win-x64 --output ./pkg/symbol-upload-windows",
     "act": "act --secret-file .env"
   },
   "repository": {
@@ -48,12 +52,6 @@
   "homepage": "https://github.com/BugSplat-Git/symbol-upload#readme",
   "pkg": {
     "scripts": "./dist/**/*.js",
-    "targets": [
-      "node18-macos-x64",
-      "node18-linux-x64",
-      "node18-win-x64"
-    ],
-    "outputPath": "./pkg",
     "compress": "GZip",
     "assets": [
       "package.json",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start:dsym": "ts-node -r dotenv/config ./bin/index.ts -d ./spec/support -f \"*.dSYM\" -a BugSplatTester -v \"1.0 (1)\"",
     "start:xcarchive": "ts-node -r dotenv/config ./bin/index.ts -d ./spec/support -f \"*.xcarchive/**/*.dSYM\" -v \"4.5.6 (1)\"",
     "start:elf": "ts-node -r dotenv/config ./bin/index.ts -d ./spec -f \"**/*.elf\"",
+    "start:dump_syms": "ts-node -r dotenv/config ./bin/index.ts -d ./spec -f \"**/*.dSYM\" -m",
     "test": "ts-node node_modules/jasmine/bin/jasmine",
     "help": "ts-node ./bin/index.ts -h",
     "clean": "rimraf ./dist",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "outputPath": "./pkg",
     "compress": "GZip",
     "assets": [
-      "package.json"
+      "package.json",
+      "node_modules/node-dump-syms/dist/native/index.addon"
     ]
   },
   "devDependencies": {
@@ -91,5 +92,8 @@
     "promise-retry": "^2.0.1",
     "rxjs": "^7.8.1",
     "workerpool": "^6.5.1"
+  },
+  "optionalDependencies": {
+    "node-dump-syms": "^3.0.6"
   }
 }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,5 +1,4 @@
 import { ApiClient, SymbolsApiClient, VersionsApiClient } from "@bugsplat/js-api-client";
-import { glob } from "glob";
 import { basename, dirname, extname, join, relative } from "node:path";
 import { pool } from "workerpool";
 import { getDSymFileInfos } from './dsym';
@@ -11,16 +10,7 @@ import { createWorkersFromSymbolFiles } from './worker';
 
 const workerPool = pool(join(__dirname, 'compression.js'));
 
-export async function uploadSymbolFiles(bugsplat: ApiClient, database: string, application: string, version: string, directory: string, filesGlob: string) {
-    const globPattern = `${directory}/${filesGlob}`;
-
-    const symbolFilePaths = await glob(globPattern);
-
-    if (!symbolFilePaths.length) {
-        throw new Error(`Could not find any files to upload using glob ${globPattern}!`);
-    }
-
-    console.log(`Found files:\n ${symbolFilePaths.join('\n')}`);
+export async function uploadSymbolFiles(bugsplat: ApiClient, database: string, application: string, version: string, directory: string, symbolFilePaths: Array<string>) {
     console.log(`About to upload symbols for ${database}-${application}-${version}...`);
 
     const symbolsApiClient = new SymbolsApiClient(bugsplat);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -55,11 +55,11 @@ export class UploadWorker {
         let tmpFileName = '';
 
         if (dbgId && !isZip) {
-            tmpFileName = join(tmpDir, `${fileName}.gz`);
-            let tmpSubdir = join(tmpDir, dirname(fileName));
+            const tmpSubdir = join(tmpDir, dirname(fileName));
             if (!existsSync(tmpSubdir)) {
                 mkdirSync(tmpSubdir, { recursive: true });
             }
+            tmpFileName = join(tmpSubdir, `${fileName}.gz`);
             client = this.symbolsClient;
             await this.pool.exec('createGzipFile', [path, tmpFileName]);
         } else if (!isZip) {


### PR DESCRIPTION
Adds dump_syms functionality via the Mozilla dump_syms crate. When invoked with the `-m` flag, any binaries the glob finds will be converted to `.sym` files and uploaded.

Depends on https://github.com/BugSplat-Git/node-dump-syms/pull/8

### TODO 
- [x] Release updated node-dump-syms
- [x] Test Windows
- [x] Test Linux
- [x] Package with pkg

BREAKING CHANGE: removes glob support from `uploadSymbolFiles`