### PR TITLE
fix: include extension in windows module name

### DIFF
--- a/spec/sym.spec.ts
+++ b/spec/sym.spec.ts
@@ -34,7 +34,7 @@ describe('getSymFileInfo', () => {
     });
 
     it('should get module name for file with line feeds and carriage returns', async () => {
-        const expected = 'windows';
+        const expected = 'windows.pdb';
 
         const { moduleName } = await getSymFileInfo('./spec/support/windows.sym');
 

--- a/src/sym.ts
+++ b/src/sym.ts
@@ -3,9 +3,10 @@ import firstline from "firstline";
 export async function getSymFileInfo(path: string): Promise<{ dbgId: string, moduleName: string }> {
     try {
         const firstLine = await firstline(path);
-        const matches = Array.from(firstLine?.matchAll(/([0-9a-fA-F]{33,34})\s+([^\.]*).*$/gm));
+        const matches = Array.from(firstLine?.matchAll(/([0-9a-fA-F]{33,34})\s+(.*)$/gm));
         const dbgId = matches?.at(0)?.at(1) || '';
-        const moduleName = matches?.at(0)?.at(2) || '';
+        const moduleNameWithExt = matches?.at(0)?.at(2) || '';
+        const moduleName = removeNonWindowsExtensions(moduleNameWithExt);
         return {
             dbgId,
             moduleName
@@ -17,4 +18,14 @@ export async function getSymFileInfo(path: string): Promise<{ dbgId: string, mod
             moduleName: ''
         };
     }
+}
+
+function removeNonWindowsExtensions(moduleName: string): string {
+    const windowsExtensions = ['.dll', '.pdb', '.exe'];
+
+    if (windowsExtensions.some(ext => moduleName.endsWith(ext))) {
+        return moduleName;
+    }
+    
+    return moduleName.split('.')[0];
 }


### PR DESCRIPTION
Apparently Windows is the only platform where the minidump-stackwalk backend looks for modules containing extensions.