### PR TITLE
fix: sym file lookup

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -113,8 +113,7 @@ import { CommandLineDefinition, argDefinitions, usageDefinitions } from './comma
             const nodeDumpSyms = (await import('node-dump-syms')).dumpSyms;
             symbolFilePaths = symbolFilePaths.map(file => {
                 console.log(`Dumping syms for ${file}...`);
-                const fileNoExt = file.split('.')[0]; // Handle macos .app.dSYM etc.
-                const symFile = join(tmpDir, `${basename(fileNoExt)}.sym`);
+                const symFile = join(tmpDir, `${getSymFileBaseName(file)}.sym`);
                 nodeDumpSyms(file, symFile);
                 return symFile;
             });
@@ -178,6 +177,14 @@ async function getCommandLineOptions(argDefinitions: Array<CommandLineDefinition
         application,
         version
     }
+}
+// The rust-minidump-stackwalker symbol lookup implementation removes some extensions from the sym file name for symbol lookups.
+// This is a bit of a mystery and is subject to change when we learn more about how it works.
+// For now, remove any non .so extension in the sym file's base name to satisfy the minidump-stackwalker symbol lookup.
+function getSymFileBaseName(file: string): string {
+    const linuxSoExtensionPattern = /\.so\.+.*$/gm;
+    const fileNoExt = file.split('.')[0];
+    return linuxSoExtensionPattern.test(file) ? basename(file) : basename(fileNoExt);   
 }
 
 function logHelpAndExit() {

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -182,7 +182,7 @@ async function getCommandLineOptions(argDefinitions: Array<CommandLineDefinition
 // This is a bit of a mystery and is subject to change when we learn more about how it works.
 // For now, remove any non .so extension in the sym file's base name to satisfy the minidump-stackwalker symbol lookup.
 function getSymFileBaseName(file: string): string {
-    const linuxSoExtensionPattern = /\.so\.+.*$/gm;
+    const linuxSoExtensionPattern = /\.so\.?.*$/gm;
     const fileNoExt = file.split('.')[0];
     return linuxSoExtensionPattern.test(file) ? basename(file) : basename(fileNoExt);   
 }

--- a/spec/sym.spec.ts
+++ b/spec/sym.spec.ts
@@ -18,7 +18,7 @@ describe('getSymFileInfo', () => {
     });
 
     it('should get module name for file with line feeds', async () => {
-        const expected = 'libc++_shared';
+        const expected = 'libc++_shared.so';
 
         const { moduleName } = await getSymFileInfo('./spec/support/android.sym');
 

--- a/src/sym.ts
+++ b/src/sym.ts
@@ -25,7 +25,7 @@ export async function getSymFileInfo(path: string): Promise<{ dbgId: string, mod
 // For now, remove some module name extensions to satisfy the minidump-stackwalker symbol lookup.
 function removeIgnoredExtensions(moduleName: string): string {
     // We've seen .pdb, .so, .so.0, and .so.6 in the module lookup
-    const ignoredExtensions = [/\.pdb$/gm, /\.so\.+.*$/gm];
+    const ignoredExtensions = [/\.pdb$/gm, /\.so\.?.*$/gm];
 
     if (ignoredExtensions.some((regex) => regex.test(moduleName))) {
         return moduleName;


### PR DESCRIPTION
Work around weirdness in rust-minidump-stackwalker symbol file lookup requests.

###
- [x] TODO BG test