### PR TITLE
fix!: enoent searching for symbol files

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -122,7 +122,7 @@ import { CommandLineDefinition, argDefinitions, usageDefinitions } from './comma
         }
     }
 
-    await uploadSymbolFiles(bugsplat, database, application, version, directory, symbolFilePaths);
+    await uploadSymbolFiles(bugsplat, database, application, version, symbolFilePaths);
     await safeRemoveTmp();
     process.exit(0);
 })().catch(async (error) => {

--- a/spec/dsym.spec.ts
+++ b/spec/dsym.spec.ts
@@ -6,17 +6,15 @@ describe('dsym', () => {
             return expectAsync(getDSymFileInfos('spec/support/bugsplat.pdb')).toBeResolvedTo(jasmine.arrayContaining([]));
         });
 
-        it('should return path, relativePath, dbgIds, module names for macho files', () => {
+        it('should return path, dbgIds, module names for macho files', () => {
             return expectAsync(getDSymFileInfos('spec/support/bugsplat.app.dSYM')).toBeResolvedTo(jasmine.arrayContaining([
                 {
                     path: jasmine.stringMatching(/tmp[\/\\]2dd1bd2706fa384da5a3a8265921cf9a[\/\\]BugsplatTester/),
-                    relativePath: jasmine.stringMatching(/2dd1bd2706fa384da5a3a8265921cf9a[\/\\]BugsplatTester/),
                     dbgId: '2dd1bd2706fa384da5a3a8265921cf9a',
                     moduleName: 'BugsplatTester',
                 },
                 {
                     path: jasmine.stringMatching(/tmp[\/\\]2ce192f6c5963e66b06aa22bde5756a0[\/\\]BugsplatTester/),
-                    relativePath: jasmine.stringMatching(/2ce192f6c5963e66b06aa22bde5756a0[\/\\]BugsplatTester/),
                     dbgId: '2ce192f6c5963e66b06aa22bde5756a0',
                     moduleName: 'BugsplatTester',
                 }

--- a/spec/worker.spec.ts
+++ b/spec/worker.spec.ts
@@ -151,7 +151,6 @@ function createFakeSymbolFileInfos(count: number) {
     return Array.from(Array(count).keys())
         .map((i) => createFakeSymbolFileInfo({
             path: `path${i}`,
-            relativePath: `relativePath${i}`,
             moduleName: `moduleName${i}`,
             dbgId: `dbgId${i}`
         })
@@ -163,7 +162,6 @@ function createFakeSymbolFileInfo(params: Partial<SymbolFileInfo>): SymbolFileIn
         path: 'path',
         moduleName: 'moduleName',
         dbgId: 'dbgId',
-        relativePath: 'relativePath',
     };
     return {
         ...defaults,

--- a/src/dsym.ts
+++ b/src/dsym.ts
@@ -22,7 +22,6 @@ export async function getDSymFileInfos(path: string): Promise<SymbolFileInfo[]> 
                 await macho.writeFile(path);
                 return {
                     path,
-                    relativePath,
                     dbgId,
                     moduleName,
                 }

--- a/src/info.ts
+++ b/src/info.ts
@@ -1,6 +1,5 @@
 export type SymbolFileInfo = {
     path: string;
-    relativePath: string;
     moduleName: string;
     dbgId: string;
 }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -10,6 +10,7 @@ import { createWorkersFromSymbolFiles } from './worker';
 
 const workerPool = pool(join(__dirname, 'compression.js'));
 
+// TODO BG should symbolFilePaths be relative to directory?
 export async function uploadSymbolFiles(bugsplat: ApiClient, database: string, application: string, version: string, directory: string, symbolFilePaths: Array<string>) {
     console.log(`About to upload symbols for ${database}-${application}-${version}...`);
 

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,5 +1,5 @@
 import { ApiClient, SymbolsApiClient, VersionsApiClient } from "@bugsplat/js-api-client";
-import { basename, dirname, extname, join, relative } from "node:path";
+import { basename, extname, join } from "node:path";
 import { pool } from "workerpool";
 import { getDSymFileInfos } from './dsym';
 import { tryGetElfUUID } from './elf';
@@ -10,14 +10,13 @@ import { createWorkersFromSymbolFiles } from './worker';
 
 const workerPool = pool(join(__dirname, 'compression.js'));
 
-// TODO BG should symbolFilePaths be relative to directory?
-export async function uploadSymbolFiles(bugsplat: ApiClient, database: string, application: string, version: string, directory: string, symbolFilePaths: Array<string>) {
+export async function uploadSymbolFiles(bugsplat: ApiClient, database: string, application: string, version: string, symbolFilePaths: Array<string>) {
     console.log(`About to upload symbols for ${database}-${application}-${version}...`);
 
     const symbolsApiClient = new SymbolsApiClient(bugsplat);
     const versionsApiClient = new VersionsApiClient(bugsplat);
     const symbolFiles = await Promise.all(
-        symbolFilePaths.map(async (symbolFilePath) => await createSymbolFileInfos(directory, symbolFilePath))
+        symbolFilePaths.map(async (symbolFilePath) => await createSymbolFileInfos(symbolFilePath))
     ).then(array => array.flat());
     const workers = createWorkersFromSymbolFiles(workerPool, symbolFiles, [symbolsApiClient, versionsApiClient]);
     const uploads = workers.map((worker) => worker.upload(database, application, version));
@@ -26,9 +25,8 @@ export async function uploadSymbolFiles(bugsplat: ApiClient, database: string, a
     console.log('Symbols uploaded successfully!');
 }
 
-async function createSymbolFileInfos(searchDirectory: string, symbolFilePath: string): Promise<SymbolFileInfo[]> {
+async function createSymbolFileInfos(symbolFilePath: string): Promise<SymbolFileInfo[]> {
     const path = symbolFilePath;
-    const relativePath = relative(searchDirectory, dirname(path));
     const extLowerCase = extname(path).toLowerCase();
     const isSymFile = extLowerCase.includes('.sym');
     const isPdbFile = extLowerCase.includes('.pdb');
@@ -43,7 +41,6 @@ async function createSymbolFileInfos(searchDirectory: string, symbolFilePath: st
             path,
             dbgId,
             moduleName,
-            relativePath
         } as SymbolFileInfo];
     }
 
@@ -54,7 +51,6 @@ async function createSymbolFileInfos(searchDirectory: string, symbolFilePath: st
             path,
             dbgId,
             moduleName,
-            relativePath
         } as SymbolFileInfo];
     }
 
@@ -64,7 +60,6 @@ async function createSymbolFileInfos(searchDirectory: string, symbolFilePath: st
             path,
             dbgId,
             moduleName,
-            relativePath
         } as SymbolFileInfo];
     }
 
@@ -79,7 +74,6 @@ async function createSymbolFileInfos(searchDirectory: string, symbolFilePath: st
             path,
             dbgId,
             moduleName,
-            relativePath
         } as SymbolFileInfo];
     }
 
@@ -89,6 +83,5 @@ async function createSymbolFileInfos(searchDirectory: string, symbolFilePath: st
         path,
         dbgId,
         moduleName,
-        relativePath
     } as SymbolFileInfo];
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -42,9 +42,8 @@ export class UploadWorker {
     }
 
     private async uploadSingle(database: string, application: string, version: string, symbolFileInfo: SymbolFileInfo): Promise<void> {
-        let { path, relativePath } = symbolFileInfo;
-        const { dbgId, moduleName } = symbolFileInfo;
-        const folderPrefix = relativePath.replace(/\\/g, '-').replace(/\//g, '-');
+        const { dbgId, moduleName, path } = symbolFileInfo;
+        const folderPrefix = dirname(path).replace(/\\/g, '-').replace(/\//g, '-');
         const fileName = folderPrefix ? [folderPrefix, basename(path)].join('-') : basename(path);
         const uncompressedSize = await this.stat(path).then(stats => stats.size);
         const timestamp = Math.round(new Date().getTime() / 1000);


### PR DESCRIPTION
There's some weird logic in here we use so that files with the same name but in different folders don't overwrite one another in the temp directory. To avoid this, we prefix the file name with the path to the file. Since 2 files with the same name can't be in the same folder this works because the prefix is always different, but it also gives us some idea where the symbol came from.

Fixes #108

BREAKING CHANGE: changes signature of public function uploadSymbolFiles