### PR TITLE
fix: support database in package.json

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -156,12 +156,16 @@ async function fileExists(path: string): Promise<boolean> {
 
 async function getCommandLineOptions(argDefinitions: Array<CommandLineDefinition>): Promise<CommandLineOptions> {
     const options = commandLineArgs(argDefinitions);
-    let { application, version } = options;
+    let { database, application, version } = options;
     let packageJson;
-
-    if (!application || !version) {
+    
+    if (!database || !application || !version) {
         const packageJsonPath = './package.json';
         packageJson = await fileExists(packageJsonPath) ? JSON.parse((await readFile(packageJsonPath)).toString()) : null;
+    }
+
+    if (!database && packageJson) {
+        database = packageJson.database;
     }
 
     if (!application && packageJson) {
@@ -174,6 +178,7 @@ async function getCommandLineOptions(argDefinitions: Array<CommandLineDefinition
 
     return {
         ...options,
+        database,
         application,
         version
     }


### PR DESCRIPTION
Allows user to specify BugSplat database in package.json. This is really useful for electron as it gives us an accessible spot to share the value between the native, main, and renderer handlers.