### PR TITLE
feat: support prx and sprx

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,6 +57,19 @@
             "type": "node"
         },
         {
+            "name": "Start: elf",
+            "request": "launch",
+            "runtimeArgs": [
+                "run-script",
+                "start:elf",
+            ],
+            "runtimeExecutable": "npm",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        {
             "name": "Start: dump_syms",
             "request": "launch",
             "runtimeArgs": [

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -32,8 +32,8 @@ async function createSymbolFileInfos(searchDirectory: string, symbolFilePath: st
     const isSymFile = extLowerCase.includes('.sym');
     const isPdbFile = extLowerCase.includes('.pdb');
     const isPeFile = extLowerCase.includes('.exe') || extLowerCase.includes('.dll');
-    const isElfFile = extLowerCase.includes('.elf') || extLowerCase.includes('.self');
     const isDsymFile = extLowerCase.includes('.dsym');
+    const isElfFile = elfExtensions.some((ext) => extLowerCase.includes(ext));
 
     if (isPdbFile) {
         const dbgId = await tryGetPdbGuid(path);
@@ -91,3 +91,5 @@ async function createSymbolFileInfos(searchDirectory: string, symbolFilePath: st
         relativePath
     } as SymbolFileInfo];
 }
+
+const elfExtensions = ['.elf', '.self', '.prx', '.sprx'];


### PR DESCRIPTION
Extension .prx was requested by Warhorse and I noticed that .sprx was also searched for by the debugger. I believe .prx is the extension for PlayStation Plugins and .sprx is a signed version of .prx (similar to .elf and .self)

Before:
<img width="1728" alt="Screenshot 2024-05-15 at 9 34 56 AM" src="https://github.com/BugSplat-Git/symbol-upload/assets/2646053/30aaf7cb-96b1-4975-b77c-6bc3133495dc">

After:
<img width="1728" alt="image" src="https://github.com/BugSplat-Git/symbol-upload/assets/2646053/7e743c44-b840-42ae-9fe0-43e45efeab19">
