### PR TITLE
fix: add windows compatibility

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   test-my-action:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: ☑️ Checkout
       uses: actions/checkout@v3
@@ -14,9 +17,9 @@ jobs:
     - name: 📦 Symbols
       uses: ./
       with:
-        clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
-        clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
-        database: "${{ secrets.BUGSPLAT_DATABASE }}"
+        clientId: ${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}
+        clientSecret: ${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}
+        database: ${{ secrets.BUGSPLAT_DATABASE }}
         application: "symbol-upload-test"
         version: "1.0"
         directory: "spec/support"

--- a/action.yaml
+++ b/action.yaml
@@ -59,11 +59,11 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Install symbol-upload
-      shell: bash
+      shell: pwsh
       run: npm i -g @bugsplat/symbol-upload
         
     - name: Run symbol-upload
-      shell: bash
+      shell: pwsh
       run: >-
         symbol-upload
         -b "${{ inputs.database }}"


### PR DESCRIPTION
### Description

Use pwsh as runner, according to ChatGPT it's available on Windows, macOS, and Linux GitHub Actions runners. Also updated test action to run on windows-latest, ubuntu-latest, and macos-latest to verify.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
