### PR TITLE
feat: allow nss uploads for Nintendo

### DIFF
--- a/src/elf.ts
+++ b/src/elf.ts
@@ -25,7 +25,7 @@ function getUUID(section: Buffer, path: string, offset = 0) {
   
   // Nintendo GUIDs seem to be 32 or 40 hex chars 0 padded to 64 hex chars
   // Until we know more, pad it ourselves with this hacky workaround
-  if (extname(path) === '.nss') {
+  if (extname(path)?.toLowerCase() === '.nss') {
     uuid = uuid.padEnd(64, '0');
   }
 

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -95,4 +95,4 @@ async function createSymbolFileInfos(symbolFilePath: string): Promise<SymbolFile
     } as SymbolFileInfo];
 }
 
-const elfExtensions = ['.elf', '.self', '.prx', '.sprx'];
+const elfExtensions = ['.elf', '.self', '.prx', '.sprx', '.nss'];


### PR DESCRIPTION
### Description

NSS appears to just be a typical ELF file. There is some weirdness with the build IDs... here's what we get in the crash report for `module_id`:

```
1e0b323c7d1a24dd142f3d3f94ac642600000000000000000000000000000000
```
but symbol-upload gets

```
1e0b323c7d1a24dd142f3d3f94ac6426
```

We've seen length of 32 and length of 40. For now we're just 0 padding to reach a length of 64 because a fix that used big ints in elfy would be a ton of work.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
