### PR TITLE
chore: fix unit tests

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -110,7 +110,8 @@ export class UploadWorker {
 
         const endTime = new Date();
         const seconds = (endTime.getTime() - startTime.getTime()) / 1000;
-        console.log(`Worker ${this.id} uploaded ${name}! (${prettyBytes(size)} @ ${prettyBytes(size / seconds)}/sec)`);
+        const rate = size / seconds || 0;
+        console.log(`Worker ${this.id} uploaded ${name}! (${prettyBytes(size)} @ ${prettyBytes(rate)}/sec)`);
         return {
             name,
             size


### PR DESCRIPTION
### Description

Test runs so fast the time ends up being 0 causing prettyBytes to fail because anything divided by 0 is NaN.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
