### PR TITLE
fix: don't fire uploads promises all at once

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -12,7 +12,7 @@ import { createWorkersFromSymbolFiles } from './worker';
 
 // TODO BG re-enable after moving to node 22
 // const maxWorkers = availableParallelism();
-const maxWorkers = cpus().length;
+const maxWorkers = cpus().length - 1;
 const workerPool = pool(join(__dirname, 'compression.js'), { maxWorkers });
 
 export async function uploadSymbolFiles(bugsplat: ApiClient, database: string, application: string, version: string, symbolFilePaths: Array<string>) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -39,9 +39,13 @@ export class UploadWorker {
     async upload(database: string, application: string, version: string): Promise<UploadStats[]> {
         console.log(`Worker ${this.id} uploading ${this.symbolFileInfos.length} symbol files...`);
 
-        return Promise.all(
-            this.symbolFileInfos.map((symbolFileInfo) => this.uploadSingle(database, application, version, symbolFileInfo))
-        );
+        const results = [] as UploadStats[];
+
+        for (const symbolFileInfo of this.symbolFileInfos) {
+            results.push(await this.uploadSingle(database, application, version, symbolFileInfo));
+        }
+        
+        return results;
     }
 
     private async uploadSingle(database: string, application: string, version: string, symbolFileInfo: SymbolFileInfo): Promise<UploadStats> {


### PR DESCRIPTION
For large file lists we're firing off like 40000 promises at once. Node's async I/O is supposed to handle this, but it seems like at these numbers everything falls apart. We open hundreds of file descriptors, and requests start to fail because we're absolutely hammering the backend and perhaps even overwhelming the sending machine. This change awaits each upload requests so there's at most 16 going simultaneously instead of an indeterminate amount.