### PR TITLE
fix: symbol-upload-linux fails if tmp dir doesn't exist

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -3,9 +3,9 @@ import { ApiClient, BugSplatApiClient, OAuthClientCredentialsClient, VersionsApi
 import commandLineArgs, { CommandLineOptions } from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
 import { glob } from 'glob';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { mkdir, readFile, stat } from 'node:fs/promises';
-import { basename, extname, join } from 'node:path';
+import { basename, dirname, extname, join } from 'node:path';
 import { importNodeDumpSyms } from '../src/preload';
 import { safeRemoveTmp, tmpDir } from '../src/tmp';
 import { uploadSymbolFiles } from '../src/upload';
@@ -114,6 +114,7 @@ import { CommandLineDefinition, argDefinitions, usageDefinitions } from './comma
             symbolFilePaths = symbolFilePaths.map(file => {
                 console.log(`Dumping syms for ${file}...`);
                 const symFile = join(tmpDir, `${getSymFileBaseName(file)}.sym`);
+                mkdirSync(dirname(symFile), { recursive: true });
                 nodeDumpSyms(file, symFile);
                 return symFile;
             });

--- a/sea/windows.ps1
+++ b/sea/windows.ps1
@@ -1,4 +1,5 @@
 node --experimental-sea-config sea-config.json
 node -e "require('fs').copyFileSync(process.execPath, '.\\dist\\symbol-upload-windows.exe')"
-"C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\signtool.exe" remove /s .\dist\symbol-upload-windows.exe
+$signtool = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\signtool.exe"
+& $signtool remove /s ".\dist\symbol-upload-windows.exe"
 npx postject .\dist\symbol-upload-windows.exe NODE_SEA_BLOB .\dist\sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2

--- a/sea/windows.ps1
+++ b/sea/windows.ps1
@@ -1,5 +1,4 @@
 node --experimental-sea-config sea-config.json
 node -e "require('fs').copyFileSync(process.execPath, '.\\dist\\symbol-upload-windows.exe')"
-signtool remove /s .\dist\symbol-upload-windows.exe
+"C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\signtool.exe" remove /s .\dist\symbol-upload-windows.exe
 npx postject .\dist\symbol-upload-windows.exe NODE_SEA_BLOB .\dist\sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
-#signtool sign /fd SHA256 symbol-upload-windows.exe 


### PR DESCRIPTION
### Description

Create tmp dir before asking node-dump-syms to write there.

Fixes #127

### TODO

- [ ] Update bugsplat-unreal

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
