### PR TITLE
fix: remove incorrect must match text

### DIFF
--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -27,14 +27,14 @@ export const argDefinitions: Array<CommandLineDefinition> = [
         alias: 'a',
         type: String,
         typeLabel: '{underline string}',
-        description: 'The name of your application. The value of application must match the value used to post crash reports. If not provided symbol-upload will attempt to use the value of the name field in package.json if it exists in the current working directory.',
+        description: 'The name of your application. If not provided symbol-upload will attempt to use the value of the name field in package.json if it exists in the current working directory.',
     },
     {
         name: 'version',
         alias: 'v',
         type: String,
         typeLabel: '{underline string}',
-        description: 'Your application\'s version. The value of version must match the value used to post crash reports. If not provided symbol-upload will attempt to use the value of the version field in package.json if it exists in the current working directory.',
+        description: 'Your application\'s version. If not provided symbol-upload will attempt to use the value of the version field in package.json if it exists in the current working directory.',
     },
     {
         name: 'user',


### PR DESCRIPTION
### Description

For most platforms, an exact match of application and version is not required. The exception to this rule is JavaScript source maps and we have examples that demonstrate how to do this correctly.

### Checklist

- [ ] Tested manually
- [ ] Unit tests pass with no errors or warnings
- [ ] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
