### PR TITLE
chore: require node 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "firstline": "^2.0.2",
         "glob": "^10.3.10",
         "macho-uuid": "^1.3.1",
-        "node-dump-syms": "^3.0.8",
         "pdb-guid": "^1.0.7",
         "pretty-bytes": "^5.6.0",
         "promise-retry": "^2.0.1",
@@ -50,6 +49,9 @@
         "rimraf": "^5.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "optionalDependencies": {
         "node-dump-syms": "^3.0.8"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "symbol-upload": "./dist/bin/index.js"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
### Description

Didn't realize we broke Second Life by going to node 22. Doing a major version rev to reflect the breaking change.

Now customers get a warning:

```bash
bobby@Mr-Presidents-MacBook-Pro symbol-upload % npm i
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@bugsplat/symbol-upload@9.2.3',
npm WARN EBADENGINE   required: { node: '>=22' },
npm WARN EBADENGINE   current: { node: 'v20.11.1', npm: '10.2.4' }
npm WARN EBADENGINE }
```

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
