### PR TITLE
fix: update action.yaml for dumpSyms support

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -49,6 +49,11 @@ inputs:
     type: string
     required: false
     default: '20'
+  dumpSyms:
+    description: "Use dumpSyms to generate symbols"
+    type: boolean
+    required: false
+    default: false    
 
 runs:
   using: composite
@@ -75,3 +80,4 @@ runs:
         -s "${{ inputs.clientSecret }}"
         -f "${{ inputs.files }}"
         -d "${{ inputs.directory }}"
+        ${{ inputs.dumpSyms == 'true' && '-m' || '' }}


### PR DESCRIPTION
### Description
The dumpSyms switch was not included in the exposed parameters/inputs fto the github action. 

This PR enables it. 
--dumpSyms is a simple switch, so we need more logic than the other string params. 
Also, pwsh is weird, so we check dumpSyms value to be explicitly set to the 'true' value

when using dumpSyms you may need to install `node-dump-syms`
```
      - name: Install node-dump-syms
        if: runner.os == 'Linux'
        run: npm install -g @bugsplat/node-dump-syms     
```

Note: this has been tested on Windows only as this fix has moved me forward to needing to resolve other issues in my pipeline before I can properly test on macOS and Linux as well. 

Fixes #135 

### Checklist

- [X] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
