### PR TITLE
fix: update command line help

### DIFF
--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -76,7 +76,7 @@ export const argDefinitions: Array<CommandLineDefinition> = [
         type: String,
         defaultValue: '*.js.map',
         typeLabel: '{underline string} (optional)',
-        description: 'Glob pattern that specifies a set of files to upload. For example, **/*.\\{pdb,exe,dll\\} will recursively search for .pdb, .exe, and .dll files. Defaults to \'*.js.map\'',
+        description: 'Glob pattern that specifies a set of files to upload. For example, **/*.\\{pdb,exe,dll\\} will recursively search for .pdb, .exe, and .dll files. Defaults to \"*.js.map\"',
     },
     {
         name: 'directory',


### PR DESCRIPTION
### Description

Changed singled quotes to double quotes in the files usage example.

Fixes #143 

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
