### PR TITLE
fix: dump_syms fails due to incorrect path handling

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -10,7 +10,7 @@ import commandLineUsage from 'command-line-usage';
 import { glob } from 'glob';
 import { existsSync, mkdirSync } from 'node:fs';
 import { mkdir, readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { fileExists } from '../src/fs';
 import { importNodeDumpSyms } from '../src/preload';
 import { getNormalizedSymModuleName } from '../src/sym';
@@ -21,6 +21,7 @@ import {
   argDefinitions,
   usageDefinitions,
 } from './command-line-definitions';
+import { randomUUID } from 'node:crypto';
 
 (async () => {
   let {
@@ -133,7 +134,7 @@ import {
 
     symbolFilePaths = symbolFilePaths.map((file) => {
       console.log(`Dumping syms for ${file}...`);
-      const symFile = join(tmpDir, `${getNormalizedSymModuleName(file)}.sym`);
+      const symFile = join(tmpDir, randomUUID(), `${getNormalizedSymModuleName(basename(file))}.sym`);
       mkdirSync(dirname(symFile), { recursive: true });
       nodeDumpSyms(file, symFile);
       return symFile;

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -8,12 +8,13 @@ import {
 import commandLineArgs, { CommandLineOptions } from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
 import { glob } from 'glob';
+import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync } from 'node:fs';
 import { mkdir, readFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { fileExists } from '../src/fs';
 import { importNodeDumpSyms } from '../src/preload';
-import { getNormalizedSymModuleName } from '../src/sym';
+import { getNormalizedSymFileName } from '../src/sym';
 import { safeRemoveTmp, tmpDir } from '../src/tmp';
 import { uploadSymbolFiles } from '../src/upload';
 import {
@@ -21,7 +22,6 @@ import {
   argDefinitions,
   usageDefinitions,
 } from './command-line-definitions';
-import { randomUUID } from 'node:crypto';
 
 (async () => {
   let {
@@ -134,7 +134,7 @@ import { randomUUID } from 'node:crypto';
 
     symbolFilePaths = symbolFilePaths.map((file) => {
       console.log(`Dumping syms for ${file}...`);
-      const symFile = join(tmpDir, randomUUID(), `${getNormalizedSymModuleName(basename(file))}.sym`);
+      const symFile = join(tmpDir, randomUUID(), getNormalizedSymFileName(basename(file)));
       mkdirSync(dirname(symFile), { recursive: true });
       nodeDumpSyms(file, symFile);
       return symFile;

--- a/spec/sym.spec.ts
+++ b/spec/sym.spec.ts
@@ -1,51 +1,137 @@
-import { getSymFileInfo } from '../src/sym';
+import { getNormalizedSymFileName, getNormalizedSymModuleName, getSymFileInfo } from '../src/sym';
 
-describe('getSymFileInfo', () => {
-    it('should get debug id for file with a 33 character debug id', async () => {
-        const expected = '83AE77A7796BDF7DCE8CE3564B3B5D650';
+describe('sym', () => {
+    describe('getSymFileInfo', () => {
+        it('should get debug id for file with a 33 character debug id', async () => {
+            const expected = '83AE77A7796BDF7DCE8CE3564B3B5D650';
 
-        const { dbgId } = await getSymFileInfo('./spec/support/android.sym');
+            const { dbgId } = await getSymFileInfo('./spec/support/android.sym');
 
-        expect(dbgId).toBe(expected);
+            expect(dbgId).toBe(expected);
+        });
+
+        it('should get debug id for file with a 34 character debug id', async () => {
+            const expected = '9DD7CE5C705C45B09BEE297B84B5B9881c';
+
+            const { dbgId } = await getSymFileInfo('./spec/support/windows.sym');
+
+            expect(dbgId).toBe(expected);
+        });
+
+        it('should get module name for file with line feeds', async () => {
+            const expected = 'libc++_shared.so';
+
+            const { moduleName } = await getSymFileInfo('./spec/support/android.sym');
+
+            expect(moduleName).toBe(expected);
+        });
+
+        it('should get module name for file with spaces in module name', async () => {
+            const expected = 'Electron Helper (GPU)';
+
+            const { moduleName } = await getSymFileInfo('./spec/support/spaces.sym');
+
+            expect(moduleName).toBe(expected);
+        });
+
+        it('should get module name for file with line feeds and carriage returns', async () => {
+            const expected = 'windows.pdb';
+
+            const { moduleName } = await getSymFileInfo('./spec/support/windows.sym');
+
+            expect(moduleName).toBe(expected);
+        });
+
+        it('should get module name for file with .dylib.dSYM extension', async () => {
+            const expected = 'liba.dylib';
+
+            const { moduleName } = await getSymFileInfo('./spec/support/liba.dylib.sym');
+
+            expect(moduleName).toBe(expected);
+        });
     });
 
-    it('should get debug id for file with a 34 character debug id', async () => {
-        const expected = '9DD7CE5C705C45B09BEE297B84B5B9881c';
+    describe('getNormalizedSymModuleName', () => {
+        it('should get normalized sym module name for file with .dylib.dSYM extension', () => {
+            const expected = 'liba.dylib';
 
-        const { dbgId } = await getSymFileInfo('./spec/support/windows.sym');
+            const normalizedSymModuleName = getNormalizedSymModuleName('liba.dylib.dSYM');
 
-        expect(dbgId).toBe(expected);
+            expect(normalizedSymModuleName).toBe(expected);
+        });
+
+        it('should get normalized sym module name for file with .app.dSYM extension', () => {
+            const expected = 'Electron';
+
+            const normalizedSymModuleName = getNormalizedSymModuleName('Electron.app.dSYM');
+
+            expect(normalizedSymModuleName).toBe(expected);
+        });
+
+        it('should get normalized sym module name for file with .so extension', () => {
+            const expected = 'liba.so';
+
+            const normalizedSymModuleName = getNormalizedSymModuleName('liba.so');
+
+            expect(normalizedSymModuleName).toBe(expected);
+        });
+
+        it('should get normalized sym module name for file with .so.0 extension', () => {
+            const expected = 'liba.so.0';
+
+            const normalizedSymModuleName = getNormalizedSymModuleName('liba.so.0');
+
+            expect(normalizedSymModuleName).toBe(expected);
+        });
+        
+        it('should get normalized sym file name for file with a .pdb extension', () => {
+            const expected = 'windows.pdb';
+
+            const normalizedSymModuleName = getNormalizedSymModuleName('windows.pdb');
+
+            expect(normalizedSymModuleName).toBe(expected);
+        });
     });
 
-    it('should get module name for file with line feeds', async () => {
-        const expected = 'libc++_shared.so';
+    describe('getNormalizedSymFileName', () => {
+        it('should get normalized sym file name for file with .dylib.dSYM extension', () => {
+            const expected = 'liba.dylib.sym';
 
-        const { moduleName } = await getSymFileInfo('./spec/support/android.sym');
+            const normalizedSymFileName = getNormalizedSymFileName('liba.dylib.dSYM');
 
-        expect(moduleName).toBe(expected);
-    });
+            expect(normalizedSymFileName).toBe(expected);
+        });
 
-    it('should get module name for file with spaces in module name', async () => {
-        const expected = 'Electron Helper (GPU)';
+        it('should get normalized sym file name for file with .app.dSYM extension', () => {
+            const expected = 'Electron.sym';
 
-        const { moduleName } = await getSymFileInfo('./spec/support/spaces.sym');
+            const normalizedSymFileName = getNormalizedSymFileName('Electron.app.dSYM');
 
-        expect(moduleName).toBe(expected);
-    });
+            expect(normalizedSymFileName).toBe(expected);
+        });
 
-    it('should get module name for file with line feeds and carriage returns', async () => {
-        const expected = 'windows.pdb';
+        it('should get normalized sym file name for file with .so extension', () => {
+            const expected = 'liba.so.sym';
 
-        const { moduleName } = await getSymFileInfo('./spec/support/windows.sym');
+            const normalizedSymFileName = getNormalizedSymFileName('liba.so');
 
-        expect(moduleName).toBe(expected);
-    });
+            expect(normalizedSymFileName).toBe(expected);
+        });
 
-    it('should get module name for file with .dylib.dSYM extension', async () => {
-        const expected = 'liba.dylib';
+        it('should get normalized sym file name for file with .so.0 extension', () => {
+            const expected = 'liba.so.0.sym';
 
-        const { moduleName } = await getSymFileInfo('./spec/support/liba.dylib.sym');
+            const normalizedSymFileName = getNormalizedSymFileName('liba.so.0');
 
-        expect(moduleName).toBe(expected);
+            expect(normalizedSymFileName).toBe(expected);
+        });
+        
+        it('should get normalized sym file name for file with a .pdb extension', () => {
+            const expected = 'windows.sym';
+
+            const normalizedSymFileName = getNormalizedSymFileName('windows.pdb');
+
+            expect(normalizedSymFileName).toBe(expected);
+        });
     });
 });

--- a/spec/sym.spec.ts
+++ b/spec/sym.spec.ts
@@ -91,6 +91,22 @@ describe('sym', () => {
 
             expect(normalizedSymModuleName).toBe(expected);
         });
+
+        it('should get normalized sym module name for file with a .so.2.debug extension', () => {
+            const expected = 'linux.so.2';
+
+            const normalizedSymModuleName = getNormalizedSymModuleName('linux.so.2.debug');
+
+            expect(normalizedSymModuleName).toBe(expected);
+        });
+
+        it('should get normalized sym module name for file with a .debug extension', () => {
+            const expected = 'linux';
+
+            const normalizedSymModuleName = getNormalizedSymModuleName('linux.debug');
+
+            expect(normalizedSymModuleName).toBe(expected);
+        });
     });
 
     describe('getNormalizedSymFileName', () => {
@@ -130,6 +146,22 @@ describe('sym', () => {
             const expected = 'windows.sym';
 
             const normalizedSymFileName = getNormalizedSymFileName('windows.pdb');
+
+            expect(normalizedSymFileName).toBe(expected);
+        });
+
+        it('should get normalized sym file name for file with a .so.2.debug extension', () => {
+            const expected = 'linux.so.2.sym';
+
+            const normalizedSymFileName = getNormalizedSymFileName('linux.so.2.debug');
+
+            expect(normalizedSymFileName).toBe(expected);
+        });
+
+        it('should get normalized sym file name for file with a .debug extension', () => {
+            const expected = 'linux.sym';
+
+            const normalizedSymFileName = getNormalizedSymFileName('linux.debug');
 
             expect(normalizedSymFileName).toBe(expected);
         });

--- a/src/sym.ts
+++ b/src/sym.ts
@@ -30,12 +30,14 @@ export async function getSymFileInfo(
 // For now, normalize some module name extensions to satisfy the minidump-stackwalker symbol lookup.
 // When building the path, the pattern is module/GUID/file.sym
 export function getNormalizedSymModuleName(moduleName: string): string {
-  // Remove the dSYM portion for .dylib.dSYM and .app.dSYM
-  const isDsym = moduleName.toLowerCase().endsWith('.dsym');
-  if (isDsym) {
-    moduleName = moduleName.slice(0, -5);
+  // Remove the .dSYM and .debug portions for .dylib.dSYM, .app.dSYM, and .so.2.debug etc.
+  const alwaysRemoveExtensions = ['.dsym', '.debug'];
+  for (const extension of alwaysRemoveExtensions) {
+    if (moduleName.toLowerCase().endsWith(extension)) {
+      moduleName = moduleName.slice(0, -extension.length);
+    }
   }
-  
+
   // We've seen .pdb, .so, .so.0, and .so.6 in the module lookup, leave them alone
   const ignoredExtensions = [/\.pdb$/gm, /\.so\.?.*$/gm, /\.dylib$/gm];
   if (ignoredExtensions.some((regex) => regex.test(moduleName))) {
@@ -59,7 +61,14 @@ export function getNormalizedSymModuleName(moduleName: string): string {
 export function getNormalizedSymFileName(path: string): string {
   let normalizedFileName = basename(path);
 
-  // Remove the dSYM portion for .dylib.dSYM and .app.dSYM
+  // Remove the .dSYM and .debug portions for .dylib.dSYM, .app.dSYM, and .so.2.debug etc.
+  const alwaysRemoveExtensions = ['.dsym', '.debug'];
+  for (const extension of alwaysRemoveExtensions) {
+    if (normalizedFileName.toLowerCase().endsWith(extension)) {
+      normalizedFileName = normalizedFileName.slice(0, -extension.length);
+    }
+  }
+
   const isDsym = normalizedFileName.toLowerCase().endsWith('.dsym');
   if (isDsym) {
     normalizedFileName = normalizedFileName.slice(0, -5);

--- a/src/sym.ts
+++ b/src/sym.ts
@@ -69,11 +69,6 @@ export function getNormalizedSymFileName(path: string): string {
     }
   }
 
-  const isDsym = normalizedFileName.toLowerCase().endsWith('.dsym');
-  if (isDsym) {
-    normalizedFileName = normalizedFileName.slice(0, -5);
-  }
-
   // We've seen .dylib.sym, .so.sym, .so.0.sym, and .so.6.sym in the sym file lookup, leave them alone
   const ignoredExtensions = [/\.dylib$/gm, /\.so\.?.*$/gm];
   if (ignoredExtensions.some((regex) => regex.test(normalizedFileName))) {


### PR DESCRIPTION
### Description

The logic used to determine the module and sym file names used by Crashpad is bananas.

* `.pdb` exists in the module portion of the path but not the sym file name eg, `thing.pdb/GUID/thing.sym`
* `.so.*` exists in both the module portion and the sym file name eg, `thing.so.6/GUID/thing.so.6.sym`
* `.dSYM` always gets removed, and `.dylib.dSYM` gets trimmed to `thing.dylib/GUID/thing.dylib.sym` but `.app.dSYM` gets trimmed to `thing/GUID/thing.sym`
* `.debug` always gets removed, and `.so.2.debug` gets trimmed to `thing.so.2/GUID/thing.so.2.sym`

Fixes #160

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
