### PR TITLE
fix: handle dump sym errors

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -141,17 +141,34 @@ import {
       );
     }
 
-    symbolFilePaths = symbolFilePaths.map((file) => {
+    const newSymbolFilePaths: string[] = [];
+
+    for (const file of symbolFilePaths) {
       console.log(`Dumping syms for ${file}...`);
+      
       const symFile = join(
         tmpDir,
         randomUUID(),
         getNormalizedSymFileName(basename(file))
       );
+
       mkdirSync(dirname(symFile), { recursive: true });
-      nodeDumpSyms(file, symFile);
-      return symFile;
-    });
+
+      try {
+        nodeDumpSyms(file, symFile);
+      } catch (error: any) {
+        console.warn(`Failed to dump syms for ${file}: ${error?.message || error}`);
+        continue;
+      }
+
+      newSymbolFilePaths.push(symFile);
+    }
+
+    symbolFilePaths = newSymbolFilePaths;
+  }
+
+  if (!symbolFilePaths.length) {
+    throw new Error('No valid symbol files found!');
   }
 
   const symbolFileInfos = await Promise.all(


### PR DESCRIPTION
### Description

Fixes #174

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle `dump_syms` failures by skipping failed files and erroring if none are produced.
> 
> - **CLI (`bin/index.ts`)**:
>   - **Robust symbol dumping**: iterate files with a `for...of`, wrap `nodeDumpSyms` in `try/catch`, warn and skip on failure, and collect successful outputs.
>   - **Validation**: throw an error if no valid symbol files were produced after dumping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9310e0557f54e74c916b2a460ee6def247545ebf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->