### PR TITLE
fix: pin npm version for github action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -65,7 +65,7 @@ runs:
 
     - name: Install symbol-upload
       shell: pwsh
-      run: npm i -g @bugsplat/symbol-upload
+      run: npm i -g @bugsplat/symbol-upload@10.1.1
         
     - name: Run symbol-upload
       shell: pwsh


### PR DESCRIPTION
### Description

We should do a better job of pinning versions. This is a fix to get us over the immediate problem but does not close the issue as we need to come up with a better plan.

Partial fix for #176

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins the action’s install step to @bugsplat/symbol-upload@10.1.1 instead of floating latest.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0075f8c2889e4b7994a2bd35edcdc963c8f0815. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->