### PR TITLE
fix: ignore missing dbgId for unreal syms

### DIFF
--- a/spec/worker.spec.ts
+++ b/spec/worker.spec.ts
@@ -73,6 +73,17 @@ describe('worker', () => {
         });
 
         describe('legacy', () => {
+            it('should use versionsClient for .sym files without dbgId', async () => {
+                const symbolFileInfos = [
+                    createFakeSymbolFileInfo({ path: 'crashpad.sym', moduleName: 'crashpad.sym', dbgId: '' }),
+                ];
+                const worker = createUploadWorkerWithFakeReadStream(1, symbolFileInfos, clients);
+                await worker.upload(database, application, version);
+
+                expect(versionsClient.postSymbols).toHaveBeenCalledTimes(1);
+                expect(symbolsClient.postSymbols).not.toHaveBeenCalled();
+            });
+
             it('should use versionsClient for source maps without dbgId', async () => {
                 const symbolFileInfos = [
                     createFakeSymbolFileInfo({ path: 'app.js.map', moduleName: 'app.js.map', dbgId: '' }),

--- a/src/sym.ts
+++ b/src/sym.ts
@@ -57,7 +57,6 @@ export function getNormalizedSymModuleName(moduleName: string): string {
 // This is a bit of a mystery and is subject to change when we learn more about how it works.
 // For now, normalize some sym file names to satisfy the minidump-stackwalker symbol lookup.
 // When building the path, the pattern is module/GUID/file.sym
-
 export function getNormalizedSymFileName(path: string): string {
   let normalizedFileName = basename(path);
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -62,7 +62,7 @@ export class UploadWorker {
         const isSourceMap = extname(path).toLowerCase() === '.map';
 
         // Unreal binary encodes Linux sym files, fallback to legacy
-        const isUnrealSym = extname(path).toLowerCase() === '.map' && !dbgId;
+        const isUnrealSym = extname(path).toLowerCase() === '.sym' && !dbgId;
 
         if (dbgId && !isZip) {
             tmpFileName = join(tmpDir, `${fileName}-${dbgId}-${uuid}.gz`);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -58,7 +58,7 @@ export class UploadWorker {
         let name = basename(path);
         let tmpFileName = '';
 
-        // We can't store source maps by UUID, fallback to legacy
+        // We can't store source maps without a dbgId, fallback to legacy
         const isSourceMap = extname(path).toLowerCase() === '.map';
 
         // Unreal binary encodes Linux sym files, fallback to legacy

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -58,13 +58,17 @@ export class UploadWorker {
         let name = basename(path);
         let tmpFileName = '';
 
+        // We can't store source maps by UUID, fallback to legacy
         const isSourceMap = extname(path).toLowerCase() === '.map';
+
+        // Unreal binary encodes Linux sym files, fallback to legacy
+        const isUnrealSym = extname(path).toLowerCase() === '.map' && !dbgId;
 
         if (dbgId && !isZip) {
             tmpFileName = join(tmpDir, `${fileName}-${dbgId}-${uuid}.gz`);
             client = this.symbolsClient;
             await this.pool.exec('createGzipFile', [path, tmpFileName]);
-        } else if (isSourceMap || isZip) {
+        } else if (isSourceMap || isUnrealSym || isZip) {
             if (isZip) {
                 tmpFileName = path;
             } else {


### PR DESCRIPTION
### Description

Unreal has their own sym file format... It's a funky binary encoded file with no UUID. Here's what it looks like decoded:

```
[0] 0x05bc9000  _start  <out of bounds>:?
[1] 0x05bc902b  deregister_tm_clones  <out of bounds>:?
[2] 0x05bc904d  register_tm_clones  <out of bounds>:?
[3] 0x05bc9086  __do_global_dtors_aux  <out of bounds>:?
[4] 0x05bc90f5  frame_dummy  <out of bounds>:?
[5] 0x05bc9100  BuildSettings::IsLicenseeVersion()  D:/HordeSandbox/Full/Sync/Engine/Source/./Runtime/BuildSettings/Private/BuildSettings.cpp:9
[6] 0x05bc9103  ?????????????  <out of bounds>:?
[7] 0x05bc9110  BuildSettings::GetCurrentChangelist()  D:/HordeSandbox/Full/Sync/Engine/Source/./Runtime/BuildSettings/Private/BuildSettings.cpp:34
[8] 0x05bc9113  ?????????????  <out of bounds>:?
[9] 0x05bc9120  BuildSettings::GetCompatibleChangelist()  D:/HordeSandbox/Full/Sync/Engine/Source/./Runtime/BuildSettings/Private/BuildSettings.cpp:39
```

We load these files by matching application name/version. Fix by allowing this to fall through to our legacy symbol server path.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
