### PR TITLE
fix: detect invalid OAuth credentials at startup

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -5,6 +5,7 @@ import {
   OAuthClientCredentialsClient,
   VersionsApiClient,
 } from '@bugsplat/js-api-client';
+import { validateOAuthCredentials } from '../src/auth';
 import commandLineArgs, { CommandLineOptions } from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
 import { glob } from 'glob';
@@ -240,6 +241,8 @@ async function createBugSplatClient({
       host
     );
   }
+
+  await validateOAuthCredentials(clientId, clientSecret, host);
 
   return OAuthClientCredentialsClient.createAuthenticatedClient(
     clientId,

--- a/spec/auth.spec.ts
+++ b/spec/auth.spec.ts
@@ -1,0 +1,48 @@
+import { vi } from 'vitest';
+import { validateOAuthCredentials } from '../src/auth';
+
+describe('validateOAuthCredentials', () => {
+    const host = 'https://app.bugsplat.com';
+
+    function mockFetchReturning(status: number, body: unknown): typeof fetch {
+        return vi.fn().mockResolvedValue({
+            ok: status >= 200 && status < 300,
+            status,
+            json: async () => body,
+        } as Response) as unknown as typeof fetch;
+    }
+
+    it('resolves when server returns an access_token', async () => {
+        const fetchImpl = mockFetchReturning(200, { access_token: 'abc', token_type: 'Bearer' });
+
+        await expect(validateOAuthCredentials('id', 'secret', host, fetchImpl)).resolves.toBeUndefined();
+    });
+
+    it('throws BugSplatAuthenticationError when server returns 400 with unknown clientId payload', async () => {
+        const fetchImpl = mockFetchReturning(400, { message: 'Unknown clientId bad' });
+
+        await expect(validateOAuthCredentials('bad', 'bad', host, fetchImpl)).rejects.toMatchObject({ isAuthenticationError: true });
+    });
+
+    it('throws BugSplatAuthenticationError when server returns 200 without access_token', async () => {
+        const fetchImpl = mockFetchReturning(200, { error: 'invalid_client' });
+
+        await expect(validateOAuthCredentials('bad', 'bad', host, fetchImpl)).rejects.toMatchObject({ isAuthenticationError: true });
+    });
+
+    it('throws BugSplatAuthenticationError when response body is not JSON', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            json: async () => { throw new Error('not json'); },
+        } as Response) as unknown as typeof fetch;
+
+        await expect(validateOAuthCredentials('bad', 'bad', host, fetchImpl)).rejects.toMatchObject({ isAuthenticationError: true });
+    });
+
+    it('throws BugSplatAuthenticationError when fetch itself fails', async () => {
+        const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+
+        await expect(validateOAuthCredentials('id', 'secret', host, fetchImpl)).rejects.toMatchObject({ isAuthenticationError: true });
+    });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,42 @@
+import { BugSplatAuthenticationError } from '@bugsplat/js-api-client';
+
+// The OAuth library only treats HTTP 401 or a JSON body containing
+// `error: 'invalid_client'` as an auth failure. The server now returns
+// HTTP 400 with `{ message: 'Unknown clientId ...' }` for bad credentials,
+// which slips past those checks and yields a client with no access token —
+// leaving every upload to fail in a retry loop. Validate explicitly so we
+// exit immediately with a clear error.
+export async function validateOAuthCredentials(
+  clientId: string,
+  clientSecret: string,
+  host: string = 'https://app.bugsplat.com',
+  fetchImpl: typeof fetch = fetch
+): Promise<void> {
+  const url = new URL('/oauth2/authorize', host).href;
+  const body = new FormData();
+  body.append('grant_type', 'client_credentials');
+  body.append('client_id', clientId);
+  body.append('client_secret', clientSecret);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, { method: 'POST', body });
+  } catch (cause) {
+    throw new BugSplatAuthenticationError(
+      `Could not reach ${url} to authenticate: ${(cause as Error).message}`
+    );
+  }
+
+  let payload: { access_token?: string } | null = null;
+  try {
+    payload = (await response.json()) as { access_token?: string };
+  } catch {
+    // empty/non-JSON body is treated as auth failure below
+  }
+
+  if (!response.ok || !payload?.access_token) {
+    throw new BugSplatAuthenticationError(
+      'Could not authenticate, check clientId and clientSecret and try again'
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- When client credentials are invalid, the CLI was getting stuck in a retry loop instead of exiting with a clear error.
- Root cause: the BugSplat server now returns HTTP 400 with `{ message: "Unknown clientId ..." }` for bad OAuth credentials. The `@bugsplat/js-api-client` OAuth login only treats HTTP 401 or a JSON body containing `error: 'invalid_client'` as auth failure, so login silently "succeeds" with an undefined access token. Every subsequent `/symsrv/uploadUrl` call returns HTTP 200 with `{ error: 'access_denied' }` (also unrecognized as auth failure), so `getPresignedUrl` returns `undefined` and S3 throws a generic `"Failed to parse URL from undefined"` that `worker.ts` retries forever.
- Fix: validate OAuth credentials explicitly in `createBugSplatClient` before constructing the library client. Bad creds throw `BugSplatAuthenticationError`, which the existing top-level handler logs and exits 1 on.

## Test plan
- [x] `npx vitest run` — full suite passes (49 tests including 5 new auth tests)
- [x] `npm run build` — clean TypeScript build
- [x] Manual: invalid `SYMBOL_UPLOAD_CLIENT_ID` / `SYMBOL_UPLOAD_CLIENT_SECRET` now exit in <1s with `Could not authenticate, check clientId and clientSecret and try again` instead of looping
- [x] Manual: valid credentials still authenticate and proceed normally
- [ ] Verify in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)