### PR TITLE
feat: coordinate 429 backoff across upload workers (#184)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@bugsplat/elfy": "^1.0.1",
         "@bugsplat/js-api-client": "^14.0.0",
         "archiver": "^7.0.1",
+        "cockatiel": "^4.0.0",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "firstline": "^2.0.2",
@@ -1304,6 +1305,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cockatiel": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-4.0.0.tgz",
+      "integrity": "sha512-XpUZJnogsd03BGB19T9sv7Xb8SwvD8JddZV2Tlp0LNspopZ6Idv24ZwCl8vAGJ6JwODZ0zLRYVj3NWvmRcUDqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/color-convert": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsplat/elfy": "^1.0.1",
-        "@bugsplat/js-api-client": "^14.0.0",
+        "@bugsplat/js-api-client": "^15.2.0",
         "archiver": "^7.0.1",
         "cockatiel": "^4.0.0",
         "command-line-args": "^5.2.0",
@@ -59,9 +59,9 @@
       "license": "MIT"
     },
     "node_modules/@bugsplat/js-api-client": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/@bugsplat/js-api-client/-/js-api-client-14.5.0.tgz",
-      "integrity": "sha512-xryVqLhDOV6Npcw7PJcIZ4NSBaHtKOSRYnEU6osdIPNlBSkmJC9rdOtjOl5TXE1OB1fuFtExY0DwJJjgzDvBgQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@bugsplat/js-api-client/-/js-api-client-15.2.0.tgz",
+      "integrity": "sha512-xoPAQgnLlq7DfDvhwM4uuBNHT7KqhmcGrpfO9eE0O4/mFnfaRS7BbmMtAA8r3GGhMt/XLlN3woQVYxh2t/3IXw==",
       "license": "MIT",
       "dependencies": {
         "argument-contracts": "^1.2.3"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@bugsplat/elfy": "^1.0.1",
     "@bugsplat/js-api-client": "^14.0.0",
     "archiver": "^7.0.1",
+    "cockatiel": "^4.0.0",
     "command-line-args": "^5.2.0",
     "command-line-usage": "^6.1.1",
     "firstline": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "dependencies": {
     "@bugsplat/elfy": "^1.0.1",
-    "@bugsplat/js-api-client": "^14.0.0",
+    "@bugsplat/js-api-client": "^15.2.0",
     "archiver": "^7.0.1",
     "cockatiel": "^4.0.0",
     "command-line-args": "^5.2.0",

--- a/spec/retry.spec.ts
+++ b/spec/retry.spec.ts
@@ -51,6 +51,10 @@ describe('createUploadRetryPolicy', () => {
 
         await policy.execute(failing).catch(() => null);
 
+        // The first 429 trips the breaker (inner policy), so the retries that follow fast-fail with
+        // BrokenCircuitError instead of hitting the network again — only the initial attempt does.
+        expect(failing).toHaveBeenCalledTimes(1);
+
         const next = vi.fn().mockResolvedValue('ok');
         await expect(policy.execute(next)).rejects.toBeInstanceOf(BrokenCircuitError);
         expect(next).not.toHaveBeenCalled();

--- a/spec/retry.spec.ts
+++ b/spec/retry.spec.ts
@@ -1,0 +1,70 @@
+import { BugSplatAuthenticationError } from '@bugsplat/js-api-client';
+import { BrokenCircuitError } from 'cockatiel';
+import { vi } from 'vitest';
+import { createUploadRetryPolicy } from '../src/retry';
+
+// Fast timings so retries/backoff resolve instantly in tests.
+const fast = { maxAttempts: 3, initialDelay: 1, maxDelay: 1, halfOpenAfter: 1, rateLimitThreshold: 1 };
+
+function rateLimitError() {
+    return Object.assign(new Error('too many requests'), { status: 429 });
+}
+
+describe('createUploadRetryPolicy', () => {
+    it('should resolve a successful call without retrying', async () => {
+        const policy = createUploadRetryPolicy(fast);
+        const fn = vi.fn().mockResolvedValue('ok');
+
+        await expect(policy.execute(fn)).resolves.toBe('ok');
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry transient errors up to maxAttempts times', async () => {
+        const policy = createUploadRetryPolicy(fast);
+        const fn = vi.fn().mockRejectedValue(new Error('network blip'));
+
+        await expect(policy.execute(fn)).rejects.toThrow('network blip');
+        // maxAttempts is the retry count, so the function runs maxAttempts + 1 times.
+        expect(fn).toHaveBeenCalledTimes(fast.maxAttempts + 1);
+    });
+
+    it('should not retry authentication errors', async () => {
+        const policy = createUploadRetryPolicy(fast);
+        const fn = vi.fn().mockRejectedValue(new BugSplatAuthenticationError('bad credentials'));
+
+        await expect(policy.execute(fn)).rejects.toThrow('bad credentials');
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not retry max size errors', async () => {
+        const policy = createUploadRetryPolicy(fast);
+        const fn = vi.fn().mockRejectedValue(new Error('Symbol file max size exceeded'));
+
+        await expect(policy.execute(fn)).rejects.toThrow('Symbol file max size');
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should trip the breaker on a 429 so subsequent calls fast-fail without hitting the network', async () => {
+        // Keep the breaker open long enough that the second call sees it open.
+        const policy = createUploadRetryPolicy({ ...fast, halfOpenAfter: 60000 });
+        const failing = vi.fn().mockRejectedValue(rateLimitError());
+
+        await policy.execute(failing).catch(() => null);
+
+        const next = vi.fn().mockResolvedValue('ok');
+        await expect(policy.execute(next)).rejects.toBeInstanceOf(BrokenCircuitError);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should not trip the breaker on non-429 errors', async () => {
+        const policy = createUploadRetryPolicy({ ...fast, halfOpenAfter: 60000 });
+        const failing = vi.fn().mockRejectedValue(new Error('network blip'));
+
+        await policy.execute(failing).catch(() => null);
+
+        // Breaker only trips on 429s, so the next call still reaches the function.
+        const next = vi.fn().mockResolvedValue('ok');
+        await expect(policy.execute(next)).resolves.toBe('ok');
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+});

--- a/spec/worker.spec.ts
+++ b/spec/worker.spec.ts
@@ -1,6 +1,6 @@
-import { BugSplatAuthenticationError, SymbolsApiClient, VersionsApiClient } from '@bugsplat/js-api-client';
+import { SymbolsApiClient, VersionsApiClient } from '@bugsplat/js-api-client';
+import { IPolicy } from 'cockatiel';
 import { availableParallelism } from 'node:os';
-import retryPromise from 'promise-retry';
 import { WorkerPool } from 'workerpool';
 import { vi } from 'vitest';
 import { SymbolFileInfo } from '../src/info';
@@ -124,71 +124,30 @@ describe('worker', () => {
             });
         });
 
-        it('should retry failed uploads', async () => {
-            const retries = 3;
-            const retrier = (func) => retryPromise(func, { retries, minTimeout: 0, maxTimeout: 0, factor: 1 });
-            const symbolFiles = createFakeSymbolFileInfos(1);
-            const workerPool = createFakeWorkerPool();
-            vi.mocked(symbolsClient.postSymbols).mockImplementation(() => Promise.reject(new Error('Failed to upload!')));
-            const worker = new UploadWorker(1, symbolFiles, workerPool, ...clients);
-            (worker as any).retryPromise = retrier;
-            (worker as any).stat = () => Promise.resolve({ size: 0, mtime: 0 });
+        it('should run each upload through the retry policy', async () => {
+            const retryPolicy = createFakePolicy();
+            const symbolFiles = createFakeSymbolFileInfos(2);
+            const worker = createUploadWorkerWithFakeReadStream(1, symbolFiles, clients, retryPolicy);
 
-            await worker.upload(database, application, version).catch(() => null);
+            await worker.upload(database, application, version);
 
-            expect(symbolsClient.postSymbols).toHaveBeenCalledTimes(retries * symbolFiles.length + 1);
+            expect(retryPolicy.execute).toHaveBeenCalledTimes(symbolFiles.length);
         });
 
         it('should destroy file stream on error', async () => {
             const readStream = {
                 destroy: vi.fn(),
             };
-            const retrier = (func) => retryPromise(func, { retries: 0 });
             const symbolFiles = createFakeSymbolFileInfos(1);
-            const workerPool = createFakeWorkerPool();
-            const worker = new UploadWorker(1, symbolFiles, workerPool, ...clients);
+            const worker = createUploadWorkerWithFakeReadStream(1, symbolFiles, clients);
             vi.mocked(symbolsClient.postSymbols).mockRejectedValue(new Error('Failed to upload!'));
             (worker as any).createReadStream = () => readStream;
-            (worker as any).retryPromise = retrier;
-            (worker as any).stat = () => Promise.resolve({ size: 0, mtime: 0 });
             (worker as any).toWeb = () => readStream;
 
             await worker.upload(database, application, version).catch(() => null);
 
             expect(readStream.destroy).toHaveBeenCalled();
         });
-
-        describe('error', () => {
-            it('should not retry authentication errors', async () => {
-                const retry = vi.fn();
-                const retrier = (func) => func(retry);
-                const symbolFiles = createFakeSymbolFileInfos(1);
-                const workerPool = createFakeWorkerPool();
-                vi.mocked(symbolsClient.postSymbols).mockImplementation(() => Promise.reject(new BugSplatAuthenticationError('Failed to upload!')));
-                const worker = new UploadWorker(1, symbolFiles, workerPool, ...clients);
-                (worker as any).retryPromise = retrier;
-                (worker as any).stat = () => Promise.resolve({ size: 0, mtime: 0 });
-    
-                await worker.upload(database, application, version).catch(() => null);
-    
-                expect(retry).not.toHaveBeenCalled();
-            });
-
-            it('should not retry max size errors', async () => {
-                const retry = vi.fn();
-                const retrier = (func) => func(retry);
-                const symbolFiles = createFakeSymbolFileInfos(1);
-                const workerPool = createFakeWorkerPool();
-                vi.mocked(symbolsClient.postSymbols).mockImplementation(() => Promise.reject(new Error('Symbol file max size exceeded!')));
-                const worker = new UploadWorker(1, symbolFiles, workerPool, ...clients);
-                (worker as any).retryPromise = retrier;
-                (worker as any).stat = () => Promise.resolve({ size: 0, mtime: 0 });
-    
-                await worker.upload(database, application, version).catch(() => null);
-    
-                expect(retry).not.toHaveBeenCalled();
-            });
-        })
     });
 });
 
@@ -221,11 +180,19 @@ function createFakeWorkerPool(): WorkerPool {
     return fakeWorkerPool;
 }
 
-function createUploadWorkerWithFakeReadStream(id: number, symbolFileInfos: any[], clients: [SymbolsApiClient, VersionsApiClient]) {
+function createUploadWorkerWithFakeReadStream(id: number, symbolFileInfos: any[], clients: [SymbolsApiClient, VersionsApiClient], retryPolicy = createFakePolicy()) {
     const workerPool = createFakeWorkerPool();
-    const worker = new UploadWorker(id, symbolFileInfos, workerPool, ...clients);
+    const worker = new UploadWorker(id, symbolFileInfos, workerPool, ...clients, retryPolicy);
     (worker as any).stat = vi.fn().mockResolvedValue({ size: 0, mtime: 0 });
     (worker as any).createReadStream = vi.fn().mockImplementation(file => file);
     (worker as any).toWeb = vi.fn().mockImplementation(file => file);
     return worker;
+}
+
+// A pass-through policy that runs the attempt exactly once. Retry/backoff/breaker behavior is
+// covered in retry.spec.ts; here we only care that the worker hands each upload to the policy.
+function createFakePolicy(): IPolicy {
+    return {
+        execute: vi.fn().mockImplementation((fn) => fn({ attempt: 0, signal: new AbortController().signal })),
+    } as unknown as IPolicy;
 }

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,0 +1,85 @@
+import { BugSplatAuthenticationError } from '@bugsplat/js-api-client';
+import {
+    BrokenCircuitError,
+    ConsecutiveBreaker,
+    ExponentialBackoff,
+    IPolicy,
+    circuitBreaker,
+    handleWhen,
+    retry,
+    wrap,
+} from 'cockatiel';
+
+export interface RetryPolicyOptions {
+    /** Number of retries before giving up on a single upload. */
+    maxAttempts?: number;
+    /** Initial retry backoff in milliseconds. */
+    initialDelay?: number;
+    /** Maximum retry backoff in milliseconds. */
+    maxDelay?: number;
+    /** How long the breaker stays open after a 429 before testing a single request, in milliseconds. */
+    halfOpenAfter?: number;
+    /** Number of consecutive 429s that trips the breaker. */
+    rateLimitThreshold?: number;
+}
+
+export function isRateLimitError(error: unknown): boolean {
+    // js-api-client throws a BugSplatRateLimitError with status 429 for rate-limited responses.
+    return (error as { status?: number } | null)?.status === 429;
+}
+
+export function isAuthenticationError(error: unknown): boolean {
+    return !!(error as BugSplatAuthenticationError | null)?.isAuthenticationError;
+}
+
+export function isMaxSizeExceededError(error: unknown): boolean {
+    const message = (error as Error | null)?.message ?? '';
+    return message.includes('Symbol file max size') || message.includes('Symbol table max size');
+}
+
+// Auth and max-size failures are permanent; retrying them just wastes requests against the rate limit.
+function isPermanent(error: unknown): boolean {
+    return isAuthenticationError(error) || isMaxSizeExceededError(error);
+}
+
+/**
+ * Builds the shared retry policy for symbol uploads. A single instance must be shared across every
+ * worker so the circuit breaker can coordinate them: because all workers upload from the same IP,
+ * one 429 trips the breaker and the rest fast-fail (and back off) instead of each burning its own
+ * request to rediscover the limit.
+ *
+ *   wrap(retry, breaker):
+ *   - breaker (inner) trips only on 429s, so rate limiting — and nothing else — pauses every worker.
+ *   - retry (outer) applies exponential backoff with decorrelated jitter to any transient failure,
+ *     including a 429 or a BrokenCircuitError from the open breaker, but never to permanent errors.
+ */
+export function createUploadRetryPolicy(options: RetryPolicyOptions = {}): IPolicy {
+    const {
+        maxAttempts = 15,
+        initialDelay = 1000,
+        maxDelay = 30000,
+        halfOpenAfter = 10000,
+        rateLimitThreshold = 1,
+    } = options;
+
+    const retryPolicy = retry(handleWhen(error => !isPermanent(error)), {
+        maxAttempts,
+        backoff: new ExponentialBackoff({ initialDelay, maxDelay }),
+    });
+
+    const breakerPolicy = circuitBreaker(handleWhen(isRateLimitError), {
+        halfOpenAfter,
+        breaker: new ConsecutiveBreaker(rateLimitThreshold),
+    });
+
+    retryPolicy.onRetry(reason => {
+        const error = 'error' in reason ? reason.error : undefined;
+        const rateLimited = error instanceof BrokenCircuitError || isRateLimitError(error);
+        const what = rateLimited ? 'Rate limited' : 'Upload request failed';
+        console.error(`${what}; backing off ${Math.round(reason.delay)}ms before retry...`);
+    });
+    breakerPolicy.onBreak(() => console.error('Rate limit hit (429) — pausing all symbol uploads...'));
+    breakerPolicy.onReset(() => console.log('Rate limit cleared — resuming symbol uploads.'));
+
+    return wrap(retryPolicy, breakerPolicy);
+}

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,4 +1,4 @@
-import { BugSplatAuthenticationError } from '@bugsplat/js-api-client';
+import { BugSplatAuthenticationError, BugSplatRateLimitError } from '@bugsplat/js-api-client';
 import {
     BrokenCircuitError,
     ConsecutiveBreaker,
@@ -24,8 +24,7 @@ export interface RetryPolicyOptions {
 }
 
 export function isRateLimitError(error: unknown): boolean {
-    // js-api-client throws a BugSplatRateLimitError with status 429 for rate-limited responses.
-    return (error as { status?: number } | null)?.status === 429;
+    return (error as BugSplatRateLimitError | null)?.status === 429;
 }
 
 export function isAuthenticationError(error: unknown): boolean {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,11 +1,12 @@
-import { BugSplatAuthenticationError, SymbolsApiClient, VersionsApiClient } from '@bugsplat/js-api-client';
+import { SymbolsApiClient, VersionsApiClient } from '@bugsplat/js-api-client';
+import { IPolicy } from 'cockatiel';
 import { ReadStream, createReadStream } from 'fs';
 import { stat } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 import prettyBytes from 'pretty-bytes';
-import retryPromise from 'promise-retry';
 import { WorkerPool } from 'workerpool';
 import { SymbolFileInfo } from './info';
+import { createUploadRetryPolicy } from './retry';
 import { tmpDir } from './tmp';
 
 export type UploadStats = { name: string, size: number };
@@ -13,17 +14,20 @@ export type UploadStats = { name: string, size: number };
 export function createWorkersFromSymbolFiles(workerPool: WorkerPool, workerCount: number, symbolFiles: SymbolFileInfo[], clients: [SymbolsApiClient, VersionsApiClient]): Array<UploadWorker> {
     const numberOfSymbols = symbolFiles.length;
 
+    // Shared across every worker in this run so the circuit breaker can coordinate them: one 429
+    // trips the breaker and all workers back off, since they all upload from the same IP.
+    const retryPolicy = createUploadRetryPolicy();
+
     if (workerCount >= numberOfSymbols) {
-        return symbolFiles.map((symbolFile, i) => new UploadWorker(i + 1, [symbolFile], workerPool, ...clients));
+        return symbolFiles.map((symbolFile, i) => new UploadWorker(i + 1, [symbolFile], workerPool, ...clients, retryPolicy));
     }
 
     const symbolFilesChunks = splitToChunks(symbolFiles, workerCount);
-    return symbolFilesChunks.map((chunk, i) => new UploadWorker(i + 1, chunk, workerPool, ...clients));
+    return symbolFilesChunks.map((chunk, i) => new UploadWorker(i + 1, chunk, workerPool, ...clients, retryPolicy));
 }
 
 export class UploadWorker {
     private createReadStream = createReadStream;
-    private retryPromise = retryPromise;
     private stat = stat;
     private toWeb = ReadStream.toWeb;
 
@@ -33,6 +37,7 @@ export class UploadWorker {
         private readonly pool: WorkerPool,
         private readonly symbolsClient: SymbolsApiClient,
         private readonly versionsClient: VersionsApiClient,
+        private readonly retryPolicy: IPolicy,
     ) { }
 
     async upload(database: string, application: string, version: string): Promise<UploadStats[]> {
@@ -87,7 +92,9 @@ export class UploadWorker {
 
         console.log(`Worker ${this.id} uploading ${name}...`);
 
-        await this.retryPromise(async (retry) => {
+        // The shared retry policy owns all retry/backoff/coordination (see retry.ts).
+        // We just hand it a single upload attempt; it decides whether and when to retry.
+        await this.retryPolicy.execute(async () => {
             const symFileReadStream = this.createReadStream(tmpFileName);
             const file = this.toWeb(symFileReadStream);
             const symbolFile = {
@@ -100,25 +107,14 @@ export class UploadWorker {
                 moduleName
             };
 
-            return client.postSymbols(database, application, version, [symbolFile])
-                .catch((error: Error | BugSplatAuthenticationError) => {
-                    // Don't try and cancel the web stream, it's locked by the tee operation in the symbols client.
-                    // Cancelling the file stream should be safe and seems like a good thing to do...
-                    symFileReadStream.destroy();
-
-                    if (isAuthenticationError(error)) {
-                        console.error(`Worker ${this.id} failed to upload ${name}: ${error.message}!`);
-                        throw error;
-                    }
-
-                    if (isMaxSizeExceededError(error)) {
-                        console.error(`Worker ${this.id} failed to upload ${name}: ${error.message}!`);
-                        throw error;
-                    }
-
-                    console.error(`Worker ${this.id} failed to upload ${name} with error: ${error.message}! Retrying...`)
-                    retry(error);
-                })
+            try {
+                await client.postSymbols(database, application, version, [symbolFile]);
+            } catch (error) {
+                // Don't try and cancel the web stream, it's locked by the tee operation in the symbols client.
+                // Cancelling the file stream should be safe and seems like a good thing to do...
+                symFileReadStream.destroy();
+                throw error;
+            }
         });
 
         const endTime = new Date();
@@ -139,12 +135,4 @@ function splitToChunks<T>(array: Array<T>, parts: number): Array<Array<T>> {
         result.push(copy.splice(0, Math.ceil(array.length / parts)));
     }
     return result;
-}
-
-function isAuthenticationError(error: Error | BugSplatAuthenticationError): error is BugSplatAuthenticationError {
-    return (error as BugSplatAuthenticationError).isAuthenticationError;
-}
-
-function isMaxSizeExceededError(error: Error): boolean {
-    return error.message.includes('Symbol file max size') || error.message.includes('Symbol table max size');
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -94,28 +94,33 @@ export class UploadWorker {
 
         // The shared retry policy owns all retry/backoff/coordination (see retry.ts).
         // We just hand it a single upload attempt; it decides whether and when to retry.
-        await this.retryPolicy.execute(async () => {
-            const symFileReadStream = this.createReadStream(tmpFileName);
-            const file = this.toWeb(symFileReadStream);
-            const symbolFile = {
-                name,
-                size,
-                file,
-                uncompressedSize,
-                dbgId,
-                lastModified,
-                moduleName
-            };
+        try {
+            await this.retryPolicy.execute(async () => {
+                const symFileReadStream = this.createReadStream(tmpFileName);
+                const file = this.toWeb(symFileReadStream);
+                const symbolFile = {
+                    name,
+                    size,
+                    file,
+                    uncompressedSize,
+                    dbgId,
+                    lastModified,
+                    moduleName
+                };
 
-            try {
-                await client.postSymbols(database, application, version, [symbolFile]);
-            } catch (error) {
-                // Don't try and cancel the web stream, it's locked by the tee operation in the symbols client.
-                // Cancelling the file stream should be safe and seems like a good thing to do...
-                symFileReadStream.destroy();
-                throw error;
-            }
-        });
+                try {
+                    await client.postSymbols(database, application, version, [symbolFile]);
+                } catch (error) {
+                    // Don't try and cancel the web stream, it's locked by the tee operation in the symbols client.
+                    // Cancelling the file stream should be safe and seems like a good thing to do...
+                    symFileReadStream.destroy();
+                    throw error;
+                }
+            });
+        } catch (error) {
+            console.error(`Worker ${this.id} failed to upload ${name}: ${(error as Error).message}`);
+            throw error;
+        }
 
         const endTime = new Date();
         const seconds = (endTime.getTime() - startTime.getTime()) / 1000;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -46,9 +46,14 @@ export class UploadWorker {
         const results = [] as UploadStats[];
 
         for (const symbolFileInfo of this.symbolFileInfos) {
-            results.push(await this.uploadSingle(database, application, version, symbolFileInfo));
+            try {
+                results.push(await this.uploadSingle(database, application, version, symbolFileInfo));
+            } catch (error) {
+                console.error(`Worker ${this.id} failed to upload ${symbolFileInfo.path}: ${(error as Error).message}`);
+                throw error;
+            }
         }
-        
+
         return results;
     }
 
@@ -92,35 +97,28 @@ export class UploadWorker {
 
         console.log(`Worker ${this.id} uploading ${name}...`);
 
-        // The shared retry policy owns all retry/backoff/coordination (see retry.ts).
-        // We just hand it a single upload attempt; it decides whether and when to retry.
-        try {
-            await this.retryPolicy.execute(async () => {
-                const symFileReadStream = this.createReadStream(tmpFileName);
-                const file = this.toWeb(symFileReadStream);
-                const symbolFile = {
-                    name,
-                    size,
-                    file,
-                    uncompressedSize,
-                    dbgId,
-                    lastModified,
-                    moduleName
-                };
+        await this.retryPolicy.execute(async () => {
+            const symFileReadStream = this.createReadStream(tmpFileName);
+            const file = this.toWeb(symFileReadStream);
+            const symbolFile = {
+                name,
+                size,
+                file,
+                uncompressedSize,
+                dbgId,
+                lastModified,
+                moduleName
+            };
 
-                try {
-                    await client.postSymbols(database, application, version, [symbolFile]);
-                } catch (error) {
-                    // Don't try and cancel the web stream, it's locked by the tee operation in the symbols client.
-                    // Cancelling the file stream should be safe and seems like a good thing to do...
-                    symFileReadStream.destroy();
-                    throw error;
-                }
-            });
-        } catch (error) {
-            console.error(`Worker ${this.id} failed to upload ${name}: ${(error as Error).message}`);
-            throw error;
-        }
+            try {
+                await client.postSymbols(database, application, version, [symbolFile]);
+            } catch (error) {
+                // Don't try and cancel the web stream, it's locked by the tee operation in the symbols client.
+                // Cancelling the file stream should be safe and seems like a good thing to do...
+                symFileReadStream.destroy();
+                throw error;
+            }
+        });
 
         const endTime = new Date();
         const seconds = (endTime.getTime() - startTime.getTime()) / 1000;


### PR DESCRIPTION
## Why

Closes #184. A customer's WAF rate-limits a single IP (2000 requests / 5 min → HTTP 429). Symbol uploads run on a pool of workers that **all share that IP**, so when the limit is hit, every worker independently retries and keeps the IP over budget — a thundering herd that sustains the 429s.

## What

Every upload now goes through a single **shared** [`cockatiel`](https://github.com/connor4312/cockatiel) policy (`src/retry.ts`, `createUploadRetryPolicy`):

- **retry** — exponential backoff with decorrelated jitter for transient failures, bounded by `maxAttempts`. Auth and max-size errors are never retried.
- **circuit breaker** — trips **only on 429s**. Because the one policy instance is shared across all workers (created once in `createWorkersFromSymbolFiles`), a single 429 opens the breaker and **all** workers fast-fail/back off until a probe succeeds, instead of each burning a request to rediscover the limit.

`worker.ts` no longer owns any retry/backoff logic — it hands one attempt to the shared policy, and the `upload()` loop logs per-file context on terminal failure.

429 detection keys off `BugSplatRateLimitError` (`status === 429`), thrown by `@bugsplat/js-api-client`.

## Dependency

Requires the typed `BugSplatRateLimitError` from js-api-client (https://github.com/BugSplat-Git/bugsplat-js-api-client/pull/168):
- [x] js-api-client PR merged
- [x] Published and bumped here → `@bugsplat/js-api-client@^15.2.0`

## Tests

- `spec/retry.spec.ts` — policy behavior: success passes through, transient errors retry to `maxAttempts`, auth/max-size never retry, a 429 trips the breaker so subsequent calls fast-fail (and the first 429 only hits the network once), non-429 errors don't trip it.
- `spec/worker.spec.ts` — worker hands each upload to the shared policy; stream destroyed on error.
- Full suite green (48 tests), `tsc` clean against js-api-client 15.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)