### PR TITLE
chore: automate GitHub release creation on tag push

### DIFF
--- a/.github/workflows/sea.yaml
+++ b/.github/workflows/sea.yaml
@@ -56,6 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
 
     steps:
     - name: ⬇️ Download Artifacts

--- a/.github/workflows/sea.yaml
+++ b/.github/workflows/sea.yaml
@@ -50,3 +50,39 @@ jobs:
       with:
         name: ${{ matrix.artifact_name }}
         path: dist/${{ matrix.file_name }} # Uploads the artifact with a platform-specific name and path
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: ⬇️ Download Artifacts
+      uses: actions/download-artifact@v7
+      with:
+        path: artifacts
+
+    - name: 📦 Stage Release Assets
+      run: |
+        mkdir release
+        cp artifacts/symbol-upload-linux/symbol-upload-linux release/symbol-upload-linux
+        cp artifacts/symbol-upload-macos/symbol-upload-macos release/symbol-upload-macos
+        cp artifacts/symbol-upload-macos-intel/symbol-upload-macos release/symbol-upload-macos-intel
+        cp artifacts/symbol-upload-windows.exe/symbol-upload-windows.exe release/symbol-upload-windows.exe
+        chmod +x release/symbol-upload-linux release/symbol-upload-macos release/symbol-upload-macos-intel
+
+    - name: 🚀 Create Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        PRERELEASE=""
+        if [[ "$TAG" == *-* ]]; then
+          PRERELEASE="--prerelease"
+        fi
+        if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          gh release upload "$TAG" release/* --repo "$GITHUB_REPOSITORY" --clobber
+        else
+          gh release create "$TAG" release/* --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes $PRERELEASE
+        fi


### PR DESCRIPTION
## What

Automates GitHub release creation so it's no longer a manual step in the release process.

Adds a `release` job to `.github/workflows/sea.yaml` that runs after the build matrix. It:

- Downloads all four build artifacts produced by the matrix
- Stages them into a `release/` directory, renaming the macOS Intel binary from its internal name `symbol-upload-macos` to `symbol-upload-macos-intel`
- Restores the executable bit (`chmod +x`) on the macOS and Linux binaries, which artifacts strip
- Creates a GitHub release for the pushed tag with auto-generated notes and attaches all four binaries (`symbol-upload-linux`, `symbol-upload-macos`, `symbol-upload-macos-intel`, `symbol-upload-windows.exe`)

## Why

Previously the workflow only published the binaries as workflow artifacts, leaving a maintainer to download three of them, `chmod +x` each, create the release, and upload the assets by hand.

## Notes

- The `release` job is granted `contents: write`; the rest of the workflow is unchanged.
- Tags containing a hyphen (e.g. `v10.4.0-rc.1`) are published as **prereleases**, so "Latest" keeps pointing at stable versions.
- If a release for the tag already exists, assets are uploaded with `--clobber` instead of failing — making re-runs idempotent.

Closes #196
