### PR TITLE
feat: support .nrs symbol files

### DIFF
--- a/src/info.ts
+++ b/src/info.ts
@@ -62,4 +62,4 @@ export async function createSymbolFileInfos(symbolFilePath: string): Promise<Sym
     } as SymbolFileInfo];
 }
 
-const elfExtensions = ['.elf', '.self', '.prx', '.sprx', '.nss'];
+const elfExtensions = ['.elf', '.self', '.prx', '.sprx', '.nss', '.nrs'];


### PR DESCRIPTION
## Summary

Adds support for `.nrs` symbol files. `.nrs` files are dynamic libraries for Nintendo Switch and follow the same ELF format as the already-supported `.nss` files, so they're added to the `elfExtensions` list and processed identically (debug ID extracted via `tryGetElfUUID`).

## Changes

- `src/info.ts`: add `.nrs` to `elfExtensions`

## Testing

- `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)