### PR TITLE
fix: drop deprecated transitive glob by upgrading archiver to v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bugsplat/elfy": "^1.0.1",
         "@bugsplat/js-api-client": "^15.2.0",
-        "archiver": "^7.0.1",
+        "archiver": "^8.0.0",
         "cockatiel": "^4.0.0",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
@@ -27,7 +27,7 @@
         "symbol-upload": "dist/bin/index.js"
       },
       "devDependencies": {
-        "@types/archiver": "^6.0.2",
+        "@types/archiver": "^8.0.0",
         "@types/command-line-args": "^5.2.0",
         "@types/command-line-usage": "^5.0.2",
         "@types/firstline": "^2.0.2",
@@ -513,12 +513,13 @@
       }
     },
     "node_modules/@types/archiver": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
-      "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-YpXPbEuv9+eUIPPQWUPahj3cvs9isWRuF+J4z+KbdYVDO3rWorWQFxUVHnwPu2AgKwvgpki5F2VMX0Xx+mX45A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/node": "*",
         "@types/readdir-glob": "*"
       }
     },
@@ -815,39 +816,23 @@
       }
     },
     "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.2",
         "async": "^3.2.4",
         "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
+        "is-stream": "^4.0.0",
         "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^3.0.0",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^7.0.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
     "node_modules/arg": {
@@ -1390,19 +1375,19 @@
       }
     },
     "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
         "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -1438,16 +1423,16 @@
       }
     },
     "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
     "node_modules/create-require": {
@@ -2163,6 +2148,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -2576,12 +2562,12 @@
       }
     },
     "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3041,12 +3027,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -3801,39 +3781,18 @@
       }
     },
     "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-3.0.0.tgz",
+      "integrity": "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/yqnn"
       }
     },
     "node_modules/reduce-flatten": {
@@ -5123,17 +5082,17 @@
       }
     },
     "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "symbol-upload": "./dist/bin/index.js"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12.0"
   },
   "files": [
     "dist"
@@ -34,10 +34,10 @@
     "prerelease": "npm run build",
     "release": "npm publish --access public",
     "ncc": "npx ncc build ./bin/index.ts -o ./dist",
-    "bpkg:compression": "npx bpkg ./src/compression.js ./dist/compression.js",
+    "bundle:compression": "node ./scripts/bundle-compression.js",
     "bpkg:node-dump-syms": "npx bpkg ./node_modules/node-dump-syms ./dist/node-dump-syms.js",
     "prebuild:sea": "npm run clean",
-    "build:sea": "run-s ncc bpkg:compression bpkg:node-dump-syms",
+    "build:sea": "run-s ncc bundle:compression bpkg:node-dump-syms",
     "presea:macos": "npm run build:sea",
     "presea:windows": "npm run build:sea",
     "presea:linux": "npm run build:sea",
@@ -64,7 +64,7 @@
   },
   "homepage": "https://github.com/BugSplat-Git/symbol-upload#readme",
   "devDependencies": {
-    "@types/archiver": "^6.0.2",
+    "@types/archiver": "^8.0.0",
     "@types/command-line-args": "^5.2.0",
     "@types/command-line-usage": "^5.0.2",
     "@types/firstline": "^2.0.2",
@@ -85,7 +85,7 @@
   "dependencies": {
     "@bugsplat/elfy": "^1.0.1",
     "@bugsplat/js-api-client": "^15.2.0",
-    "archiver": "^7.0.1",
+    "archiver": "^8.0.0",
     "cockatiel": "^4.0.0",
     "command-line-args": "^5.2.0",
     "command-line-usage": "^6.1.1",
@@ -99,10 +99,5 @@
   },
   "optionalDependencies": {
     "node-dump-syms": "^3.0.13"
-  },
-  "overrides": {
-    "archiver-utils": {
-      "glob": "^13.0.6"
-    }
   }
 }

--- a/scripts/bundle-compression.js
+++ b/scripts/bundle-compression.js
@@ -1,0 +1,19 @@
+const ncc = require('@vercel/ncc');
+const { mkdirSync, writeFileSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+
+// archiver v8 is ESM-only, which bpkg can't bundle; ncc inlines it into a single CJS worker file.
+const input = resolve(__dirname, '..', 'src', 'compression.js');
+const outDir = resolve(__dirname, '..', 'dist');
+const outFile = join(outDir, 'compression.js');
+
+ncc(input, { minify: false, sourceMap: false })
+  .then(({ code }) => {
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(outFile, code);
+    console.log(`Bundled compression worker -> ${outFile}`);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/compression.js
+++ b/src/compression.js
@@ -3,7 +3,7 @@ const { basename } = require('node:path');
 const { lstat } = require('node:fs/promises');
 const { pipeline } = require('node:stream/promises');
 const { createGzip } = require('node:zlib');
-const archiver = require('archiver');
+const { ZipArchive } = require('archiver');
 const workerpool = require('workerpool');
 
 async function createGzipFile(inputFilePath, outputFilePath) {
@@ -20,7 +20,7 @@ async function createZipFile(inputFilePath, outputFilePath) {
   try {
     output = createWriteStream(outputFilePath);
     await new Promise(async (resolve, reject) => {
-      const zip = archiver('zip');
+      const zip = new ZipArchive();
 
       zip.pipe(output);
       zip.on('error', reject);

--- a/src/compression.js
+++ b/src/compression.js
@@ -19,15 +19,15 @@ async function createZipFile(inputFilePath, outputFilePath) {
 
   try {
     output = createWriteStream(outputFilePath);
-    await new Promise(async (resolve, reject) => {
+    const isDirectory = await pathIsDirectory(inputFilePath);
+
+    await new Promise((resolve, reject) => {
       const zip = new ZipArchive();
 
       zip.pipe(output);
       zip.on('error', reject);
       output.on('close', resolve);
       output.on('error', reject);
-
-      const isDirectory = await pathIsDirectory(inputFilePath);
 
       if (isDirectory) {
         zip.directory(inputFilePath, basename(inputFilePath));


### PR DESCRIPTION
Fixes #193 

## Problem

Installing `@bugsplat/symbol-upload` emits a deprecation warning:

```
npm warn deprecated glob@10.5.0: Old versions of glob are not supported...
```

It reaches consumers through a single chain:

```
@bugsplat/symbol-upload → archiver@7.0.1 → archiver-utils@5.0.2 → glob@^10  (→ 10.5.0, deprecated)
```

The existing `overrides.archiver-utils.glob` only fixed our **local** tree — npm honors `overrides` only in the root project, so consumers never received them and still saw the warning. (Our direct `glob@13` and `macho-uuid`'s `glob@13` are current and fine.)

## Fix

Upgrade `archiver` `^7.0.1` → `^8.0.0`. v8 dropped `archiver-utils` entirely (now uses `readdir-glob@3` → `minimatch@10`), so there is no `glob` anywhere in its subtree.

- `archiver` → `^8.0.0`, `@types/archiver` → `^8.0.0`; removed the now-dead `overrides` block.
- `src/compression.js`: archiver@8 is ESM-only and exposes classes — `archiver('zip')` → `new ZipArchive()`. All methods used (`pipe`/`on`/`directory`/`file`/`finalize`) are unchanged.
- **SEA build:** `bpkg` can't `require()` the ESM-only archiver, so the compression worker is now bundled with `@vercel/ncc` (already a devDependency) via `scripts/bundle-compression.js`, producing a single self-contained CJS worker file. `build:sea` now runs `bundle:compression` instead of `bpkg:compression`.
- `engines.node`: `>=22` → `>=22.12.0`. The installed worker does `require('archiver')`, and `require()` of ESM is only unflagged from Node 22.12 — on 22.0–22.11 it would throw `ERR_REQUIRE_ESM` on the zip path.

## Validation

- `npm pack` + clean install of the tarball → **zero deprecation warnings**; tree contains only `glob@13`, `archiver-utils` absent.
- `npm run build` ✓
- Full suite **48/48 passing** ✓
- ncc-bundled worker spawns under `workerpool` and produces valid zip + gzip with no `node_modules` (SEA-runtime equivalent) ✓

## Note for reviewer

- I could validate the bundled worker's runtime locally but **not** the full SEA single-executable packaging — worth a CI smoke test building a binary per platform before the next release.
- `engines.node` is now `>=22.12.0`; flagging in case that affects your supported-Node policy / version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)