### PR TITLE
fix: treat bin files as elf

### DIFF
--- a/src/elf.ts
+++ b/src/elf.ts
@@ -1,19 +1,23 @@
 import { ElfFile } from '@bugsplat/elfy';
 
 export async function tryGetElfUUID(path: string) {
-  let success: boolean, section: Buffer | undefined;
+  try {
+    let success: boolean, section: Buffer | undefined;
 
-  using elfFile = await ElfFile.create(path);
-  ({ success, section } = await elfFile.tryReadSection('.note.gnu.build-id'));
+    using elfFile = await ElfFile.create(path);
+    ({ success, section } = await elfFile.tryReadSection('.note.gnu.build-id'));
 
-  if (success) {
-    return getUUID(section!, 16);
-  }
+    if (success) {
+      return getUUID(section!, 16);
+    }
 
-  ({ success, section } = await elfFile.tryReadSection('.sce_special'));
+    ({ success, section } = await elfFile.tryReadSection('.sce_special'));
 
-  if (success) {
-    return getUUID(section!);
+    if (success) {
+      return getUUID(section!);
+    }
+  } catch (error) {
+    console.log(`Could not get UUID for ${path}...`);
   }
 
   return '';

--- a/src/info.ts
+++ b/src/info.ts
@@ -18,7 +18,7 @@ export async function createSymbolFileInfos(symbolFilePath: string): Promise<Sym
     const isSymFile = extLowerCase.includes('.sym') && !isFolder;
     const isPeOrPdbFile = (extLowerCase.includes('.pdb') || extLowerCase.includes('.exe') || extLowerCase.includes('.dll')) && !isFolder;
     const isDsymBundle = extLowerCase.includes('.dsym');
-    const isElfFile = elfExtensions.some((ext) => extLowerCase.includes(ext) && !isFolder);
+    const isElfFile = elfExtensions.includes(extLowerCase) && !isFolder;
 
     if (isPeOrPdbFile) {
         const dbgId = await tryGetGuid(path);

--- a/src/info.ts
+++ b/src/info.ts
@@ -62,4 +62,4 @@ export async function createSymbolFileInfos(symbolFilePath: string): Promise<Sym
     } as SymbolFileInfo];
 }
 
-const elfExtensions = ['.elf', '.self', '.prx', '.sprx', '.nss', '.nrs'];
+const elfExtensions = ['.elf', '.self', '.prx', '.sprx', '.nss', '.nrs', '.bin'];


### PR DESCRIPTION
### Description

We were not parsing GUIDs for .bin files and thus falling back to uploading them as zips.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
