### PR TITLE
fix: skip directories when globbing symbol files

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -13,7 +13,11 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { fileExists } from '../src/fs';
-import { createSymbolFileInfos, SymbolFileInfo } from '../src/info';
+import {
+  createSymbolFileInfos,
+  filterSymbolFilePaths,
+  SymbolFileInfo,
+} from '../src/info';
 import { importNodeDumpSyms } from '../src/preload';
 import { getNormalizedSymFileName } from '../src/sym';
 import { safeRemoveTmp, tmpDir } from '../src/tmp';
@@ -124,7 +128,7 @@ import {
 
   const globPattern = `${directory}/${files}`;
 
-  let symbolFilePaths = await glob(globPattern);
+  let symbolFilePaths = await filterSymbolFilePaths(await glob(globPattern));
 
   if (!symbolFilePaths.length) {
     throw new Error(

--- a/spec/info.spec.ts
+++ b/spec/info.spec.ts
@@ -1,4 +1,7 @@
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
 import { filterSymbolFilePaths } from '../src/info';
+import { safeRemoveTmp, tmpDir } from '../src/tmp';
 
 describe('info', () => {
   describe('filterSymbolFilePaths', () => {
@@ -32,6 +35,23 @@ describe('info', () => {
         'spec/support/bugsplat.elf',
       ];
       await expect(filterSymbolFilePaths(paths)).resolves.toEqual(paths);
+    });
+
+    it('should drop directories whose extension merely starts with .dsym', async () => {
+      const notABundle = join(tmpDir, 'weird.dsym2');
+      await mkdir(notABundle, { recursive: true });
+
+      try {
+        await expect(filterSymbolFilePaths([notABundle])).resolves.toEqual([]);
+      } finally {
+        await safeRemoveTmp();
+      }
+    });
+
+    it('should surface stat errors instead of deferring them', async () => {
+      await expect(
+        filterSymbolFilePaths(['spec/support/does-not-exist.sym'])
+      ).rejects.toThrow('ENOENT');
     });
   });
 });

--- a/spec/info.spec.ts
+++ b/spec/info.spec.ts
@@ -1,0 +1,37 @@
+import { filterSymbolFilePaths } from '../src/info';
+
+describe('info', () => {
+  describe('filterSymbolFilePaths', () => {
+    it('should drop directories', async () => {
+      await expect(
+        filterSymbolFilePaths([
+          'spec/support',
+          'spec/support/bugsplat.xcarchive',
+          'spec/support/dir with spaces',
+          'spec/support/windows.sym',
+        ])
+      ).resolves.toEqual(['spec/support/windows.sym']);
+    });
+
+    it('should keep dSYM bundles', async () => {
+      await expect(
+        filterSymbolFilePaths([
+          'spec/support/bugsplat.app.dSYM',
+          'spec/support/libggcurl.dylib.dSYM',
+        ])
+      ).resolves.toEqual([
+        'spec/support/bugsplat.app.dSYM',
+        'spec/support/libggcurl.dylib.dSYM',
+      ]);
+    });
+
+    it('should keep files and preserve order', async () => {
+      const paths = [
+        'spec/support/windows.sym',
+        'spec/support/bugsplat.pdb',
+        'spec/support/bugsplat.elf',
+      ];
+      await expect(filterSymbolFilePaths(paths)).resolves.toEqual(paths);
+    });
+  });
+});

--- a/src/info.ts
+++ b/src/info.ts
@@ -11,13 +11,23 @@ export type SymbolFileInfo = {
     dbgId: string;
 }
 
+export async function filterSymbolFilePaths(symbolFilePaths: string[]): Promise<string[]> {
+    const keep = await Promise.all(
+        symbolFilePaths.map(async (path) => {
+            const isFolder = await stat(path).then((stats) => stats.isDirectory()).catch(() => false);
+            return !isFolder || isDsymBundlePath(path);
+        })
+    );
+    return symbolFilePaths.filter((_, i) => keep[i]);
+}
+
 export async function createSymbolFileInfos(symbolFilePath: string): Promise<SymbolFileInfo[]> {
     const path = symbolFilePath;
     const isFolder = await stat(path).then((stats) => stats.isDirectory());
     const extLowerCase = extname(path).toLowerCase();
     const isSymFile = extLowerCase.includes('.sym') && !isFolder;
     const isPeOrPdbFile = (extLowerCase.includes('.pdb') || extLowerCase.includes('.exe') || extLowerCase.includes('.dll')) && !isFolder;
-    const isDsymBundle = extLowerCase.includes('.dsym');
+    const isDsymBundle = isDsymBundlePath(path);
     const isElfFile = elfExtensions.includes(extLowerCase) && !isFolder;
 
     if (isPeOrPdbFile) {
@@ -60,6 +70,10 @@ export async function createSymbolFileInfos(symbolFilePath: string): Promise<Sym
         dbgId,
         moduleName,
     } as SymbolFileInfo];
+}
+
+function isDsymBundlePath(path: string): boolean {
+    return extname(path).toLowerCase().includes('.dsym');
 }
 
 const elfExtensions = ['.elf', '.self', '.prx', '.sprx', '.nss', '.nrs', '.bin'];

--- a/src/info.ts
+++ b/src/info.ts
@@ -14,7 +14,7 @@ export type SymbolFileInfo = {
 export async function filterSymbolFilePaths(symbolFilePaths: string[]): Promise<string[]> {
     const keep = await Promise.all(
         symbolFilePaths.map(async (path) => {
-            const isFolder = await stat(path).then((stats) => stats.isDirectory()).catch(() => false);
+            const isFolder = await stat(path).then((stats) => stats.isDirectory());
             return !isFolder || isDsymBundlePath(path);
         })
     );
@@ -73,7 +73,7 @@ export async function createSymbolFileInfos(symbolFilePath: string): Promise<Sym
 }
 
 function isDsymBundlePath(path: string): boolean {
-    return extname(path).toLowerCase().includes('.dsym');
+    return extname(path).toLowerCase() === '.dsym';
 }
 
 const elfExtensions = ['.elf', '.self', '.prx', '.sprx', '.nss', '.nrs', '.bin'];


### PR DESCRIPTION
Closes #204

## Problem

Running `symbol-upload` with a broad pattern like `-f "**"` matched every directory under the target folder. Those directories showed up in the `Found files:` list and then each one produced a `Failed to parse UUID for <dir>, skipping...` warning, flooding build logs.

The same spam hits the `--dumpSyms` path, where each directory reaches the native module:

```
Failed to dump syms for nested: internal error in Neon module: File nested is a directory and not a mac bundle
```

## Change

Glob results are filtered through a new `filterSymbolFilePaths` helper in `src/info.ts` before anything tries to parse them. Because the filter sits at the glob site it covers every downstream consumer — `--dumpSyms`, `--localPath`, and normal upload.

Directories are dropped, except dSYM bundles — those are directories on disk and are legitimate symbol inputs, so `-f "*.dSYM"` and `-f "**"` over an `.xcarchive` keep working.

The empty-result check now runs after filtering, so a glob that only matches directories fails with the existing `Could not find any files to upload using glob ...` error instead of silently doing nothing.

### Why not `glob({ nodir: true })`?

It looks like the obvious one-line fix, but dSYM bundles are directories, so `nodir` deletes them:

| pattern | default | `nodir: true` |
|---|---|---|
| `spec/support/*.dSYM` | 2 | **0** |
| `spec/support/bugsplat.xcarchive/**/*.dSYM` | 1 | **0** |
| `spec/support/**` | 94 | 44 (drops all 8 dSYM bundles) |

That breaks every macOS path (`start:dsym`, `start:dylib`, `start:xcarchive`, `start:dump_syms`), and does so loudly — with zero matches they would hard-fail on the `Could not find any files to upload` throw. `nodir` only knows "is a directory"; what we need is "is not a symbol file", which is not the same predicate here.

## Verification

- `npm run build` — clean
- `npm run test:run` — 51 passed (3 new in `spec/info.spec.ts`)
- Reproduced end-to-end on `origin/main` vs. this branch, against a fixture with nested directories, an empty directory, `.sym` files, and a `.dSYM` bundle.

`--localPath`, before:

```
Found files:
 .../symfixture
.../symfixture/windows.sym
.../symfixture/nested
.../symfixture/empty-dir
.../symfixture/bugsplat.app.dSYM
.../symfixture/nested/deeper
.../symfixture/bugsplat.app.dSYM/Contents
...
Failed to parse UUID for .../symfixture, skipping...
Failed to parse UUID for .../symfixture/nested, skipping...
Failed to parse UUID for .../symfixture/empty-dir, skipping...
Failed to parse UUID for .../symfixture/nested/deeper, skipping...
Failed to parse UUID for .../symfixture/bugsplat.app.dSYM/Contents, skipping...
...
```

after:

```
Found files:
 .../symfixture/windows.sym
.../symfixture/bugsplat.app.dSYM
.../symfixture/nested/deeper/spaces.sym
.../symfixture/bugsplat.app.dSYM/Contents/Resources/DWARF/BugsplatTester
```

`--dumpSyms -f "**"`, before — 7 directories reach the native module:

```
Dumping syms for .../symfixture...
Failed to dump syms for .../symfixture: internal error in Neon module: File ... is a directory and not a mac bundle
Dumping syms for nested...
Failed to dump syms for nested: internal error in Neon module: ...
Dumping syms for empty-dir...
Failed to dump syms for empty-dir: internal error in Neon module: ...
Dumping syms for bugsplat.app.dSYM/Contents...
Failed to dump syms for bugsplat.app.dSYM/Contents: internal error in Neon module: ...
...
```

after — only real inputs, and the dSYM bundle still dumps:

```
Dumping syms for windows.sym...
Dumping syms for bugsplat.app.dSYM...
Dumping syms for nested/deeper/spaces.sym...
Dumping syms for bugsplat.app.dSYM/Contents/Resources/DWARF/BugsplatTester...
```

The resulting local symbol server output is unchanged in both modes — dSYM slices are still extracted and indexed by UUID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)