### PR TITLE
feat: make the GitHub Action pinnable and self-versioning

### DIFF
--- a/.github/workflows/sea.yaml
+++ b/.github/workflows/sea.yaml
@@ -65,7 +65,9 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: '24'
-        registry-url: 'https://registry.npmjs.org'
+
+    - name: ⬆️ Upgrade npm
+      run: npm install -g npm@latest
 
     - name: 🏗️ Install Dependencies
       run: npm ci

--- a/.github/workflows/sea.yaml
+++ b/.github/workflows/sea.yaml
@@ -3,7 +3,7 @@ name: Single Executable Application
 on:
     push:
         tags:
-        - 'v*'
+        - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 
 jobs:
@@ -69,6 +69,12 @@ jobs:
     - name: 🏗️ Install Dependencies
       run: npm ci
 
+    - name: 📦 Build
+      run: npm run build
+
+    - name: 🔍 Smoke Test
+      run: node ./dist/bin/index.js -h
+
     - name: 🚀 Publish to npm
       env:
         TAG: ${{ github.ref_name }}
@@ -130,7 +136,10 @@ jobs:
       run: |
         if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           MAJOR="${TAG%%.*}"
-          gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$MAJOR" -X PATCH -f sha="$GITHUB_SHA" -F force=true >/dev/null 2>&1 \
-            || gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$MAJOR" -f sha="$GITHUB_SHA" >/dev/null
+          if gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$MAJOR" --silent >/dev/null 2>&1; then
+            gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$MAJOR" -X PATCH -f sha="$GITHUB_SHA" -F force=true >/dev/null
+          else
+            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$MAJOR" -f sha="$GITHUB_SHA" >/dev/null
+          fi
           echo "Moved $MAJOR to $GITHUB_SHA"
         fi

--- a/.github/workflows/sea.yaml
+++ b/.github/workflows/sea.yaml
@@ -72,7 +72,6 @@ jobs:
 
     - name: 🚀 Publish to npm
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         TAG: ${{ github.ref_name }}
       run: |
         VERSION=$(node -p "require('./package.json').version")
@@ -86,7 +85,7 @@ jobs:
         fi
         DIST_TAG=""
         case "$VERSION" in *-*) DIST_TAG="--tag next";; esac
-        npm publish --provenance --access public $DIST_TAG
+        npm publish --access public $DIST_TAG
 
   release:
     needs: [build, publish]

--- a/.github/workflows/sea.yaml
+++ b/.github/workflows/sea.yaml
@@ -66,9 +66,6 @@ jobs:
       with:
         node-version: '24'
 
-    - name: ⬆️ Upgrade npm
-      run: npm install -g npm@latest
-
     - name: 🏗️ Install Dependencies
       run: npm ci
 

--- a/.github/workflows/sea.yaml
+++ b/.github/workflows/sea.yaml
@@ -51,8 +51,45 @@ jobs:
         name: ${{ matrix.artifact_name }}
         path: dist/${{ matrix.file_name }} # Uploads the artifact with a platform-specific name and path
 
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - name: ☑️ Checkout
+      uses: actions/checkout@v6
+
+    - name: ⚙️ Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: 🏗️ Install Dependencies
+      run: npm ci
+
+    - name: 🚀 Publish to npm
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        VERSION=$(node -p "require('./package.json').version")
+        if [ "v$VERSION" != "$TAG" ]; then
+          echo "package.json version ($VERSION) does not match tag ($TAG)" >&2
+          exit 1
+        fi
+        if npm view "@bugsplat/symbol-upload@$VERSION" version >/dev/null 2>&1; then
+          echo "$VERSION already published, skipping"
+          exit 0
+        fi
+        DIST_TAG=""
+        case "$VERSION" in *-*) DIST_TAG="--tag next";; esac
+        npm publish --provenance --access public $DIST_TAG
+
   release:
-    needs: build
+    needs: [build, publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -86,4 +123,16 @@ jobs:
           gh release upload "$TAG" release/* --repo "$GITHUB_REPOSITORY" --clobber
         else
           gh release create "$TAG" release/* --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes $PRERELEASE
+        fi
+
+    - name: 🏷️ Update Major Tag
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          MAJOR="${TAG%%.*}"
+          gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$MAJOR" -X PATCH -f sha="$GITHUB_SHA" -F force=true >/dev/null 2>&1 \
+            || gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$MAJOR" -f sha="$GITHUB_SHA" >/dev/null
+          echo "Moved $MAJOR to $GITHUB_SHA"
         fi

--- a/README.md
+++ b/README.md
@@ -23,22 +23,22 @@ Use the `symbol-upload` action in your [GitHub Actions](https://github.com/featu
 
 ```yml
 - name: Symbols 📦
-    uses: BugSplat-Git/symbol-upload@v11
-    with:
-      clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
-      clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
-      database: "${{ secrets.BUGSPLAT_DATABASE }}"
-      application: "your-application"
-      version: "your-version"
-      files: "**/*.{pdb,exe,dll}"
-      directory: "your-build-directory"
-      node-version: "24"
-      dumpSyms: false
+  uses: BugSplat-Git/symbol-upload@v11
+  with:
+    clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
+    clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
+    database: "${{ secrets.BUGSPLAT_DATABASE }}"
+    application: "your-application"
+    version: "your-version"
+    files: "**/*.{pdb,exe,dll}"
+    directory: "your-build-directory"
+    node-version: "24"
+    dumpSyms: false
 ```
 
 Be sure to use [secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) so that you don't expose the values for `clientId`, `clientSecret`, and `database`.
 
-Pin `@v11` to track the latest 11.x release, or an exact tag like `@v11.0.0`. The action installs the `@bugsplat/symbol-upload` npm package version matching the pinned ref; set `symbol-upload-version` to override.
+Pin `@v11` to track the latest 11.x release, or an exact tag like `@v11.0.0`. The action installs the `@bugsplat/symbol-upload` npm package version matching the pinned ref; SHA and branch refs install the version recorded in that commit's `package.json`. Set `symbol-upload-version` to override.
 
 ## Command Line
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use the `symbol-upload` action in your [GitHub Actions](https://github.com/featu
 
 ```yml
 - name: Symbols 📦
-    uses: BugSplat-Git/symbol-upload@v10
+    uses: BugSplat-Git/symbol-upload@v11
     with:
       clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
       clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
@@ -38,7 +38,7 @@ Use the `symbol-upload` action in your [GitHub Actions](https://github.com/featu
 
 Be sure to use [secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) so that you don't expose the values for `clientId`, `clientSecret`, and `database`.
 
-Pin `@v10` to track the latest 10.x release, or an exact tag like `@v10.6.0`. The action installs the `@bugsplat/symbol-upload` npm package version matching the pinned ref; set `symbol-upload-version` to override.
+Pin `@v11` to track the latest 11.x release, or an exact tag like `@v11.0.0`. The action installs the `@bugsplat/symbol-upload` npm package version matching the pinned ref; set `symbol-upload-version` to override.
 
 ## Command Line
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use the `symbol-upload` action in your [GitHub Actions](https://github.com/featu
       files: "**/*.{pdb,exe,dll}"
       directory: "your-build-directory"
       node-version: "24"
-      symbol-upload-version: "10.3.1"
+      symbol-upload-version: "10.5.1"
       dumpSyms: false
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use the `symbol-upload` action in your [GitHub Actions](https://github.com/featu
 
 ```yml
 - name: Symbols 📦
-    uses: BugSplat-Git/symbol-upload@v10
+    uses: BugSplat-Git/symbol-upload@v11
     with:
       clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
       clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
@@ -38,7 +38,7 @@ Use the `symbol-upload` action in your [GitHub Actions](https://github.com/featu
 
 Be sure to use [secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) so that you don't expose the values for `clientId`, `clientSecret`, and `database`.
 
-Pin `@v10` to track the latest 10.x release, or an exact tag like `@v10.5.1`. The action installs the `@bugsplat/symbol-upload` npm package version matching the pinned ref; set `symbol-upload-version` to override.
+Pin `@v11` to track the latest 11.x release, or an exact tag like `@v11.0.0`. The action installs the `@bugsplat/symbol-upload` npm package version matching the pinned ref; set `symbol-upload-version` to override.
 
 ## Command Line
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use the `symbol-upload` action in your [GitHub Actions](https://github.com/featu
 
 ```yml
 - name: Symbols 📦
-    uses: BugSplat-Git/symbol-upload@main
+    uses: BugSplat-Git/symbol-upload@v10
     with:
       clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
       clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
@@ -33,11 +33,12 @@ Use the `symbol-upload` action in your [GitHub Actions](https://github.com/featu
       files: "**/*.{pdb,exe,dll}"
       directory: "your-build-directory"
       node-version: "24"
-      symbol-upload-version: "10.5.1"
       dumpSyms: false
 ```
 
 Be sure to use [secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) so that you don't expose the values for `clientId`, `clientSecret`, and `database`.
+
+Pin `@v10` to track the latest 10.x release, or an exact tag like `@v10.5.1`. The action installs the `@bugsplat/symbol-upload` npm package version matching the pinned ref; set `symbol-upload-version` to override.
 
 ## Command Line
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use the `symbol-upload` action in your [GitHub Actions](https://github.com/featu
 
 ```yml
 - name: Symbols 📦
-    uses: BugSplat-Git/symbol-upload@v11
+    uses: BugSplat-Git/symbol-upload@v10
     with:
       clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
       clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
@@ -38,7 +38,7 @@ Use the `symbol-upload` action in your [GitHub Actions](https://github.com/featu
 
 Be sure to use [secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) so that you don't expose the values for `clientId`, `clientSecret`, and `database`.
 
-Pin `@v11` to track the latest 11.x release, or an exact tag like `@v11.0.0`. The action installs the `@bugsplat/symbol-upload` npm package version matching the pinned ref; set `symbol-upload-version` to override.
+Pin `@v10` to track the latest 10.x release, or an exact tag like `@v10.6.0`. The action installs the `@bugsplat/symbol-upload` npm package version matching the pinned ref; set `symbol-upload-version` to override.
 
 ## Command Line
 

--- a/action.yaml
+++ b/action.yaml
@@ -76,7 +76,11 @@ runs:
       run: |
         $version = $env:VERSION
         if (-not $version) {
-          $version = if ($env:ACTION_REF -match '^v\d+(\.\d+){0,2}(-.+)?$') { $env:ACTION_REF -replace '^v', '' } else { 'latest' }
+          $version = if ($env:ACTION_REF -match '^v\d+(\.\d+){0,2}(-.+)?$') {
+            $env:ACTION_REF -replace '^v', ''
+          } else {
+            (Get-Content (Join-Path $env:GITHUB_ACTION_PATH 'package.json') -Raw | ConvertFrom-Json).version
+          }
         }
         npm i -g "@bugsplat/symbol-upload@$version"
         

--- a/action.yaml
+++ b/action.yaml
@@ -53,7 +53,7 @@ inputs:
     description: "Version of @bugsplat/symbol-upload to install from npm"
     type: string
     required: false
-    default: '10.3.1'
+    default: '10.5.1'
   dumpSyms:
     description: "Use dumpSyms to generate symbols"
     type: boolean

--- a/action.yaml
+++ b/action.yaml
@@ -50,10 +50,10 @@ inputs:
     required: false
     default: '24'
   symbol-upload-version:
-    description: "Version of @bugsplat/symbol-upload to install from npm"
+    description: "Version of @bugsplat/symbol-upload to install from npm (defaults to the version matching the action's ref)"
     type: string
     required: false
-    default: '10.5.1'
+    default: ''
   dumpSyms:
     description: "Use dumpSyms to generate symbols"
     type: boolean
@@ -70,7 +70,15 @@ runs:
 
     - name: Install symbol-upload
       shell: pwsh
-      run: npm i -g @bugsplat/symbol-upload@${{ inputs.symbol-upload-version }}
+      env:
+        VERSION: ${{ inputs.symbol-upload-version }}
+        ACTION_REF: ${{ github.action_ref }}
+      run: |
+        $version = $env:VERSION
+        if (-not $version) {
+          $version = if ($env:ACTION_REF -match '^v\d+(\.\d+){0,2}(-.+)?$') { $env:ACTION_REF -replace '^v', '' } else { 'latest' }
+        }
+        npm i -g "@bugsplat/symbol-upload@$version"
         
     - name: Run symbol-upload
       shell: pwsh

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "clean": "rimraf ./dist",
     "prebuild": "npm run clean",
     "build": "tsc",
+    "prepublishOnly": "npm run build",
     "prerelease": "npm run build",
     "release": "npm publish --access public",
     "ncc": "npx ncc build ./bin/index.ts -o ./dist",


### PR DESCRIPTION
Closes #192

## Background

Both halves of #192 were fixed in source but never reached users: #193 fixed the Node 20 / setup-node deprecations, and #200 dropped the deprecated transitive glob — but v10.5.1 sat unpublished on npm (now published ✅), and `action.yaml` pinned `symbol-upload-version` to pre-fix `10.3.1`, so Action consumers kept seeing `npm warn deprecated glob@10.5.0` regardless of what landed on `main`.

Rather than just bumping the hardcoded default (which recreates this drift every release), this PR gives the action a real versioning strategy.

## Why 11.0.0

Every pre-existing tag carries the old hardcoded `action.yaml` (e.g. pinning `@v10.5.1` as an action installs npm **10.3.1**), and nothing can retroactively fix them. Starting the self-versioning action at a new major fences those tags behind an era boundary: **any `v11.x` tag is a safe pin and a safe rollback target** — no mixed-line landmines when a consumer reaches for an old tag during an incident. It also covers the `engines.node >=22.12.0` bump that shipped in 10.5.1. The 11.0.0 package is byte-identical to 10.5.1; only the action/release plumbing changed.

## What changed

**`action.yaml`** — derives the npm version from `github.action_ref` instead of a hardcoded default:

| pinned ref | installs |
|---|---|
| `@v11.0.0` | npm `11.0.0` (exact) |
| `@v11` | npm `@11` → latest 11.x |
| `@v12.0.0-beta.1` | npm `12.0.0-beta.1` |
| `@main`, `uses: ./`, SHA | `latest` |

The `symbol-upload-version` input still overrides — it works on any tag since v10.3.1, so action choice and CLI version stay decoupled as an escape hatch.

**`.github/workflows/sea.yaml`** — tag push now:
1. **Publishes to npm** (new `publish` job): verifies the tag matches `package.json` version, skips if already published (idempotent re-runs), prereleases go to `--tag next`, authenticates via npm trusted publishing (OIDC) with automatic provenance — no `NPM_TOKEN` secret, matching the proven setup in [mcp-servers-for-revit](https://github.com/mcp-servers-for-revit/mcp-servers-for-revit)
2. Creates the GitHub release **only after publish succeeds** (`needs: [build, publish]`) — a tagged version can never again be missing from npm
3. **Force-moves the floating major tag** (`v11.0.1` → moves/creates `v11`); stable releases only, so `v11` never points at a prerelease

**`README.md`** — example now pins `@v11` instead of `@main`; documents the pinning options.

## Verification

- Derivation logic tested in pwsh 7.5.1 across all ref shapes: exact tag, major (`v10`→`10`), minor, prerelease, `main`, empty, SHA, long branch name, and explicit-input override — all correct
- Major-tag regex + dist-tag + version-mismatch bash logic smoke tested (prerelease → no tag move + `--tag next`; mismatched tag → hard fail)
- Trusted publishing shape validated against a working reference: mcp-server-for-revit publishes token-free with automatic provenance attestations
- All YAML parses clean; `npm ci` (zero deprecation warnings), `npm run build`, `npm run test:run` → 48/48 pass

## Before merging

- [ ] Configure the npm **trusted publisher** for `@bugsplat/symbol-upload`: org `BugSplat-Git`, repo `symbol-upload`, workflow `sea.yaml` (exact match, case-sensitive, `.yaml` not `.yml`), environment blank. No `NPM_TOKEN` secret needed — the publish job authenticates via OIDC (`id-token: write`). Without it the next tag push fails at the publish job (loudly, before any release is created)

## After merging

Release 11.0.0 the usual way:

```sh
git checkout main && git pull origin main
npm version major
git push origin main --follow-tags
```

The tag push does the rest: builds binaries, publishes `11.0.0` to npm, creates the GitHub release, and creates the `v11` floating tag automatically — no manual tag steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)