### PR TITLE
fix: exit cleanly so failures report a non-zero code

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -42,7 +42,8 @@ import {
   } = await getCommandLineOptions(argDefinitions);
 
   if (help) {
-    logHelpAndExit();
+    logHelp();
+    return;
   }
 
   database = database ?? process.env.BUGSPLAT_DATABASE;
@@ -52,15 +53,18 @@ import {
   clientSecret = clientSecret ?? process.env.SYMBOL_UPLOAD_CLIENT_SECRET;
 
   if (!database && !localPath) {
-    logMissingArgAndExit('database');
+    logMissingArg('database');
+    return;
   }
 
   if (!application && !localPath) {
-    logMissingArgAndExit('application');
+    logMissingArg('application');
+    return;
   }
 
   if (!version && !localPath) {
-    logMissingArgAndExit('version');
+    logMissingArg('version');
+    return;
   }
 
   if (
@@ -72,7 +76,8 @@ import {
       clientSecret,
     })
   ) {
-    logMissingAuthAndExit();
+    logMissingAuth();
+    return;
   }
 
   console.log(`Symbol upload working directory: ${process.cwd()}`);
@@ -283,22 +288,23 @@ async function getCommandLineOptions(
   };
 }
 
-function logHelpAndExit(code: number = 0) {
+function logHelp(): void {
   const help = commandLineUsage(usageDefinitions);
   console.log(help);
-  process.exit(code);
 }
 
-function logMissingArgAndExit(arg: string): void {
+function logMissingArg(arg: string): void {
   console.log(`\nMissing argument: -${arg}\n`);
-  logHelpAndExit(1);
+  logHelp();
+  process.exitCode = 1;
 }
 
-function logMissingAuthAndExit(): void {
+function logMissingAuth(): void {
   console.log(
     '\nInvalid authentication arguments: please provide either a user and password, or a clientId and clientSecret\n'
   );
-  logHelpAndExit(1);
+  logHelp();
+  process.exitCode = 1;
 }
 
 function normalizeDirectory(directory: string): string {

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -195,15 +195,17 @@ import {
       symbolFileInfos
     );
   }
-
-  await safeRemoveTmp();
 })()
-  .catch(async (error) => {
-    await safeRemoveTmp();
+  .catch((error) => {
     console.error(error.message);
     process.exitCode = 1;
   })
-  .finally(() => terminateWorkerPool());
+  // Stop the workers before removing tmpDir. A rejected upload leaves sibling workers mid-gzip, and
+  // deleting the directory out from under them means noisy worker failures and file locks on Windows.
+  .finally(async () => {
+    await terminateWorkerPool();
+    await safeRemoveTmp();
+  });
 
 async function copyFilesToLocalPath(
   symbolFileInfos: SymbolFileInfo[],

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -17,7 +17,7 @@ import { createSymbolFileInfos, SymbolFileInfo } from '../src/info';
 import { importNodeDumpSyms } from '../src/preload';
 import { getNormalizedSymFileName } from '../src/sym';
 import { safeRemoveTmp, tmpDir } from '../src/tmp';
-import { uploadSymbolFiles } from '../src/upload';
+import { terminateWorkerPool, uploadSymbolFiles } from '../src/upload';
 import {
   argDefinitions,
   CommandLineDefinition,
@@ -105,7 +105,7 @@ import {
       console.log('Symbols deleted successfully!');
     } catch (error) {
       console.error(error);
-      process.exit(1);
+      process.exitCode = 1;
     } finally {
       return;
     }
@@ -192,12 +192,13 @@ import {
   }
 
   await safeRemoveTmp();
-  process.exit(0);
-})().catch(async (error) => {
-  await safeRemoveTmp();
-  console.error(error.message);
-  process.exit(1);
-});
+})()
+  .catch(async (error) => {
+    await safeRemoveTmp();
+    console.error(error.message);
+    process.exitCode = 1;
+  })
+  .finally(() => terminateWorkerPool());
 
 async function copyFilesToLocalPath(
   symbolFileInfos: SymbolFileInfo[],

--- a/spec/bin.spec.ts
+++ b/spec/bin.spec.ts
@@ -1,0 +1,48 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const localPath = join(tmpdir(), `symbol-upload-spec-${randomUUID()}`);
+
+function runCli(args: string[]): Promise<{ code: number | null; output: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['-r', 'ts-node/register', 'bin/index.ts', ...args],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+
+    let output = '';
+    child.stdout.on('data', (data) => (output += data));
+    child.stderr.on('data', (data) => (output += data));
+    child.on('error', reject);
+    child.on('exit', (code) => resolve({ code, output }));
+  });
+}
+
+describe('bin', () => {
+  it('should exit non-zero when no symbol files match the glob', async () => {
+    const { code, output } = await runCli([
+      '-d', './spec/support',
+      '-f', '**/*.no-such-extension',
+      '-l', localPath,
+    ]);
+
+    expect(code).toBe(1);
+    expect(output).toContain('Could not find any files to upload');
+  }, 30_000);
+
+  it('should exit zero when symbol files are processed', async () => {
+    const { code } = await runCli([
+      '-d', './spec/support',
+      '-f', '*.sym',
+      '-l', localPath,
+    ]);
+
+    expect(code).toBe(0);
+  }, 30_000);
+
+  afterAll(async () => await rm(localPath, { recursive: true, force: true }));
+});

--- a/spec/bin.spec.ts
+++ b/spec/bin.spec.ts
@@ -5,12 +5,16 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const localPath = join(tmpdir(), `symbol-upload-spec-${randomUUID()}`);
+const detectForcedExit = ['-r', './spec/support/detect-forced-exit.js'];
 
-function runCli(args: string[]): Promise<{ code: number | null; output: string }> {
+function runCli(
+  args: string[],
+  nodeArgs: string[] = []
+): Promise<{ code: number | null; output: string }> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       process.execPath,
-      ['-r', 'ts-node/register', 'bin/index.ts', ...args],
+      [...nodeArgs, '-r', 'ts-node/register', 'bin/index.ts', ...args],
       { stdio: ['ignore', 'pipe', 'pipe'] }
     );
 
@@ -42,6 +46,47 @@ describe('bin', () => {
     ]);
 
     expect(code).toBe(0);
+  }, 30_000);
+
+  it('should exit non-zero when a required argument is missing', async () => {
+    const { code, output } = await runCli(['-f', '*.sym']);
+
+    expect(code).toBe(1);
+    expect(output).toContain('Missing argument');
+  }, 30_000);
+
+  // process.exit() tears the event loop down while libuv still has work in flight, which trips an
+  // assertion in src/win/async.c on Windows and loses the exit code. Draining is what makes the
+  // code reliable, so the absence of a forced exit is the behavior worth pinning.
+  it('should drain instead of forcing an exit when no symbol files match', async () => {
+    const { code, output } = await runCli(
+      [
+        '-d', './spec/support',
+        '-f', '**/*.no-such-extension',
+        '-l', localPath,
+      ],
+      detectForcedExit
+    );
+
+    expect(output).not.toContain('FORCED_EXIT');
+    expect(code).toBe(1);
+  }, 30_000);
+
+  it('should drain instead of forcing an exit on success', async () => {
+    const { code, output } = await runCli(
+      ['-d', './spec/support', '-f', '*.sym', '-l', localPath],
+      detectForcedExit
+    );
+
+    expect(output).not.toContain('FORCED_EXIT');
+    expect(code).toBe(0);
+  }, 30_000);
+
+  it('should drain instead of forcing an exit when a required argument is missing', async () => {
+    const { code, output } = await runCli(['-f', '*.sym'], detectForcedExit);
+
+    expect(output).not.toContain('FORCED_EXIT');
+    expect(code).toBe(1);
   }, 30_000);
 
   afterAll(async () => await rm(localPath, { recursive: true, force: true }));

--- a/spec/bin.spec.ts
+++ b/spec/bin.spec.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 const localPath = join(tmpdir(), `symbol-upload-spec-${randomUUID()}`);
 const detectForcedExit = ['-r', './spec/support/detect-forced-exit.js'];
+const cliTimeout = 25_000;
 
 function runCli(
   args: string[],
@@ -18,11 +19,27 @@ function runCli(
       { stdio: ['ignore', 'pipe', 'pipe'] }
     );
 
+    // Kill the child ourselves so a hang can't outlive the spec and orphan a process.
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`symbol-upload ${args.join(' ')} did not exit within ${cliTimeout}ms`));
+    }, cliTimeout);
+
     let output = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
     child.stdout.on('data', (data) => (output += data));
     child.stderr.on('data', (data) => (output += data));
-    child.on('error', reject);
-    child.on('exit', (code) => resolve({ code, output }));
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    // Resolve on close, not exit: exit fires while the stdio pipes can still have buffered output,
+    // which truncates what the assertions below read.
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ code, output });
+    });
   });
 }
 

--- a/spec/support/detect-forced-exit.js
+++ b/spec/support/detect-forced-exit.js
@@ -1,0 +1,8 @@
+// Preloaded into the CLI subprocess so specs can tell a forced process.exit()
+// apart from a natural event loop drain.
+const exit = process.exit.bind(process);
+
+process.exit = (code) => {
+  console.error('FORCED_EXIT');
+  return exit(code);
+};

--- a/spec/upload.spec.ts
+++ b/spec/upload.spec.ts
@@ -22,10 +22,13 @@ describe('upload', () => {
             const terminator = vi.fn().mockRejectedValue(new Error('Failed to terminate pool!'));
             const error = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-            await expect(terminateWorkerPool(terminator)).resolves.toBeUndefined();
+            try {
+                await expect(terminateWorkerPool(terminator)).resolves.toBeUndefined();
 
-            expect(error).toHaveBeenCalled();
-            error.mockRestore();
+                expect(error).toHaveBeenCalled();
+            } finally {
+                error.mockRestore();
+            }
         });
 
         // The pool only spawns workers once a task runs, and a spawned worker holds a MessagePort

--- a/spec/upload.spec.ts
+++ b/spec/upload.spec.ts
@@ -1,0 +1,20 @@
+import { vi } from 'vitest';
+import { terminateWorkerPool } from '../src/upload';
+
+describe('upload', () => {
+    describe('terminateWorkerPool', () => {
+        it('should resolve when the pool was never used', async () => {
+            await expect(terminateWorkerPool()).resolves.toBeUndefined();
+        });
+
+        it('should not reject if the pool fails to terminate', async () => {
+            const terminator = vi.fn().mockRejectedValue(new Error('Failed to terminate pool!'));
+            const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            await expect(terminateWorkerPool(terminator)).resolves.toBeUndefined();
+
+            expect(error).toHaveBeenCalled();
+            error.mockRestore();
+        });
+    });
+});

--- a/spec/upload.spec.ts
+++ b/spec/upload.spec.ts
@@ -1,5 +1,16 @@
+import { existsSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 import { vi } from 'vitest';
-import { terminateWorkerPool } from '../src/upload';
+import { safeRemoveTmp, tmpDir } from '../src/tmp';
+
+const postSymbolsMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('@bugsplat/js-api-client', () => ({
+    SymbolsApiClient: class { postSymbols = postSymbolsMock; },
+    VersionsApiClient: class { postSymbols = postSymbolsMock; },
+}));
+
+import { terminateWorkerPool, uploadSymbolFiles } from '../src/upload';
 
 describe('upload', () => {
     describe('terminateWorkerPool', () => {
@@ -16,5 +27,30 @@ describe('upload', () => {
             expect(error).toHaveBeenCalled();
             error.mockRestore();
         });
+
+        // The pool only spawns workers once a task runs, and a spawned worker holds a MessagePort
+        // that keeps the event loop alive. Terminating after real work is what lets the CLI exit.
+        it('should release workers spawned by an upload', async () => {
+            if (!existsSync(tmpDir)) {
+                await mkdir(tmpDir, { recursive: true });
+            }
+
+            await uploadSymbolFiles({} as never, 'db', 'app', '1.0', [
+                {
+                    path: 'spec/support/windows.sym',
+                    dbgId: '9DD7CE5C705C45B09BEE297B84B5B9881c',
+                    moduleName: 'windows.pdb',
+                },
+            ]);
+
+            expect(postSymbolsMock).toHaveBeenCalled();
+            expect(process.getActiveResourcesInfo()).toContain('MessagePort');
+
+            await expect(terminateWorkerPool()).resolves.toBeUndefined();
+
+            expect(process.getActiveResourcesInfo()).not.toContain('MessagePort');
+        }, 30_000);
+
+        afterAll(async () => await safeRemoveTmp());
     });
 });

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -10,7 +10,10 @@ const maxWorkers = availableParallelism();
 const workerPool = pool(findCompressionWorkerPath(), { maxWorkers });
 
 // Workers hold a MessagePort open, which would keep node alive forever once we stop calling process.exit().
-export async function terminateWorkerPool(terminator = () => workerPool.terminate()): Promise<void> {
+// Terminate with force so a stuck compression worker can't hold the CLI open: the default waits for
+// in-progress tasks, while force cancels them and workerpool hard-kills anything that ignores the
+// terminate message within workerTerminateTimeout.
+export async function terminateWorkerPool(terminator = () => workerPool.terminate(true)): Promise<void> {
     try {
         await terminator();
     } catch (error) {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -9,6 +9,15 @@ import { createWorkersFromSymbolFiles } from './worker';
 const maxWorkers = availableParallelism();
 const workerPool = pool(findCompressionWorkerPath(), { maxWorkers });
 
+// Workers hold a MessagePort open, which would keep node alive forever once we stop calling process.exit().
+export async function terminateWorkerPool(terminator = () => workerPool.terminate()): Promise<void> {
+    try {
+        await terminator();
+    } catch (error) {
+        console.error('Could not terminate the worker pool!', error);
+    }
+}
+
 export async function uploadSymbolFiles(bugsplat: ApiClient, database: string, application: string, version: string, symbolFileInfos: Array<SymbolFileInfo>) {
     console.log(`About to upload symbols for ${database}-${application}-${version}...`);
 


### PR DESCRIPTION
Closes #201

## Problem

The report shows a run that found no symbols yet was treated as a success:

```
Could not find any files to upload using glob Bin/Win64MasterSpeedProfiling/**/*.{pdb,exe,dll,elf,nss}!
 Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
Process successfully exited with code 0
```

The error path already called `process.exit(1)`, so the exit code was not the root cause — the libuv assertion was. `process.exit()` forces teardown while libuv still has work in flight, and on Windows that trips the assertion in `src/win/async.c`. The process dies abnormally and the caller never observes the intended code.

There really is pending work at that moment. Probing the no-symbols path right where `process.exit()` is called:

```
active resources at exit point: [ FSReqCallback ]
```

That is the tmp-directory cleanup still settling. `process.exit()` yanks the loop out from under it.

## Change

Set `process.exitCode` and let node drain the event loop and exit on its own. No `process.exit()` calls remain in shipped code.

That is only safe if nothing keeps the loop alive, which is what `process.exit(0)` was papering over. Measured with `process.getActiveResourcesInfo()`:

| stage | active handles |
|---|---|
| after `pool()` | `[]` — the pool is lazy, no workers until a task runs |
| after `pool.exec(...)` | `[ MessagePort ]` — **holds the loop open forever** |
| after `pool.terminate()` | `[]` |

So `terminateWorkerPool()` is added to `src/upload.ts` and called from a `.finally()` during teardown. It swallows and logs termination errors, mirroring `safeRemoveTmp`, so a teardown failure cannot turn a successful upload into a non-zero exit. It takes an injectable terminator, matching the `safeRemoveTmp(remover = rm)` convention already in the repo.

The help and argument-validation paths get the same treatment. `logHelpAndExit` ran after `getCommandLineOptions` had already touched the filesystem, so a typod argument on Windows had the same exposure — abort on the assertion, report success. Those helpers now log, set `process.exitCode`, and let the caller `return`.

Confirmed a completed `fetch` leaves no active handles, so authenticating before the failure does not keep the process alive either.

## Verification

- `npm run build` — clean
- `npm run test:run` — 57 passed (baseline 48)
- Every exit path exercised as a real subprocess with a 30s hang detector, since hanging is the main risk of this change:

| scenario | exit | time |
|---|---|---|
| no-match glob (the issue) | 1 | 667ms |
| successful `--localPath` | 0 | 611ms |
| `*.dSYM` bundles | 0 | 626ms |
| `--dumpSyms` | 0 | 608ms |
| `-h` | 0 | 608ms |
| missing required args | 1 | 647ms |
| invalid auth args | 1 | 593ms |

### The new tests fail without the fix

Exit-code assertions alone are worthless here — `process.exit(1)` already yields 1 on macOS and linux, so they pass with the bug present. The defect is the *forced* exit, so the specs preload a shim that flags any `process.exit()` call. Running the new `spec/bin.spec.ts` against unmodified `origin/main`:

```
✓ should exit non-zero when no symbol files match the glob
✓ should exit zero when symbol files are processed
✓ should exit non-zero when a required argument is missing
× should drain instead of forcing an exit when no symbol files match
× should drain instead of forcing an exit on success
× should drain instead of forcing an exit when a required argument is missing

Tests  3 failed | 3 passed (6)
```

All six pass on this branch.

`spec/upload.spec.ts` mocks `@bugsplat/js-api-client` so a real upload runs through the real module-level worker pool with no credentials. It asserts a `MessagePort` is live after the upload and gone after `terminateWorkerPool()`, covering the only path that actually puts work through the pool.

## Note for the reviewer

**`pr.yaml` does not test this repos code.** The action installs `@bugsplat/symbol-upload@${{ inputs.symbol-upload-version }}`, which defaults to the pinned `10.3.1` from npm, so its ubuntu/macos/windows matrix exercises a published build rather than the branch. `test.yaml` runs the unit tests on ubuntu only. The practical consequence is that **nothing in CI runs this branch on Windows**, which is the only platform where the original bug reproduces. Worth addressing separately — happy to file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)