### PR TITLE
fix: verify credentials before reporting authentication success

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -1,10 +1,5 @@
 #! /usr/bin/env node
-import {
-  ApiClient,
-  BugSplatApiClient,
-  OAuthClientCredentialsClient,
-  VersionsApiClient,
-} from '@bugsplat/js-api-client';
+import { ApiClient, VersionsApiClient } from '@bugsplat/js-api-client';
 import commandLineArgs, { CommandLineOptions } from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
 import { glob } from 'glob';
@@ -12,6 +7,7 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync } from 'node:fs';
 import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
+import { AuthenticationArgs, createBugSplatClient } from '../src/auth';
 import { fileExists } from '../src/fs';
 import {
   createSymbolFileInfos,
@@ -237,29 +233,6 @@ async function copyFilesToLocalPath(
   await writeFile(symSrvMarkerFilePath, '.');
 }
 
-async function createBugSplatClient({
-  user,
-  password,
-  clientId,
-  clientSecret,
-}: AuthenticationArgs): Promise<ApiClient> {
-  const host = process.env.BUGSPLAT_HOST;
-
-  if (user && password) {
-    return BugSplatApiClient.createAuthenticatedClientForNode(
-      user,
-      password,
-      host
-    );
-  }
-
-  return OAuthClientCredentialsClient.createAuthenticatedClient(
-    clientId,
-    clientSecret,
-    host
-  );
-}
-
 async function getCommandLineOptions(
   argDefinitions: Array<CommandLineDefinition>
 ): Promise<CommandLineOptions> {
@@ -324,11 +297,4 @@ function validAuthenticationArguments({
   clientSecret,
 }: AuthenticationArgs): boolean {
   return !!(user && password) || !!(clientId && clientSecret);
-}
-
-interface AuthenticationArgs {
-  user: string;
-  password: string;
-  clientId: string;
-  clientSecret: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsplat/elfy": "^1.0.1",
-        "@bugsplat/js-api-client": "^15.2.0",
+        "@bugsplat/js-api-client": "^15.5.0",
         "archiver": "^8.0.0",
         "cockatiel": "^4.0.0",
         "command-line-args": "^5.2.0",
@@ -46,7 +46,7 @@
         "vitest": "^4.0.7"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
         "node-dump-syms": "^3.0.13"
@@ -59,9 +59,9 @@
       "license": "MIT"
     },
     "node_modules/@bugsplat/js-api-client": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@bugsplat/js-api-client/-/js-api-client-15.2.0.tgz",
-      "integrity": "sha512-xoPAQgnLlq7DfDvhwM4uuBNHT7KqhmcGrpfO9eE0O4/mFnfaRS7BbmMtAA8r3GGhMt/XLlN3woQVYxh2t/3IXw==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/@bugsplat/js-api-client/-/js-api-client-15.5.0.tgz",
+      "integrity": "sha512-ScFMtYJEEIhdoHTVOz0/61T5C7b9NDrv1uRz2yaZs9pOb8aVimgZnVs7aXchUhnLnTyjBnDY/2qYhGu2D6RY1g==",
       "license": "MIT",
       "dependencies": {
         "argument-contracts": "^1.2.3"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "dependencies": {
     "@bugsplat/elfy": "^1.0.1",
-    "@bugsplat/js-api-client": "^15.2.0",
+    "@bugsplat/js-api-client": "^15.5.0",
     "archiver": "^8.0.0",
     "cockatiel": "^4.0.0",
     "command-line-args": "^5.2.0",

--- a/spec/auth.spec.ts
+++ b/spec/auth.spec.ts
@@ -1,0 +1,126 @@
+import {
+  BugSplatApiClient,
+  OAuthClientCredentialsClient,
+} from '@bugsplat/js-api-client';
+import { vi } from 'vitest';
+import { createBugSplatClient } from '../src/auth';
+import { isAuthenticationError } from '../src/retry';
+
+describe('createBugSplatClient', () => {
+  const host = 'https://app.bugsplat.com';
+  const oauthArgs = {
+    user: '',
+    password: '',
+    clientId: '🎫',
+    clientSecret: '🔐',
+  };
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  describe('oauth', () => {
+    it('should return an authenticated client when an access token is returned', async () => {
+      stubFetch(
+        jsonResponse(200, { token_type: 'Bearer', access_token: '🪙' })
+      );
+
+      const client = await createBugSplatClient(oauthArgs, host);
+
+      expect(client).toBeInstanceOf(OAuthClientCredentialsClient);
+    });
+
+    it('should throw for an unknown client id', async () => {
+      stubFetch(jsonResponse(400, { message: 'Unknown clientId 🎫' }));
+
+      await expect(createBugSplatClient(oauthArgs, host)).rejects.toThrow(
+        /Unknown clientId/
+      );
+    });
+
+    it('should throw an authentication error when no access token is returned', async () => {
+      stubFetch(jsonResponse(400, { message: 'Unknown clientId 🎫' }));
+
+      const error = await createBugSplatClient(oauthArgs, host).catch(
+        (error) => error
+      );
+
+      expect(isAuthenticationError(error)).toBe(true);
+    });
+
+    it('should throw for an invalid client secret', async () => {
+      stubFetch(
+        jsonResponse(200, {
+          error: 'invalid_client',
+          error_description: 'Client authentication failed',
+        })
+      );
+
+      const error = await createBugSplatClient(oauthArgs, host).catch(
+        (error) => error
+      );
+
+      expect(error.message).toBe(
+        'Could not authenticate, check credentials and try again'
+      );
+    });
+
+    it('should throw with the response status when the response has no error details', async () => {
+      stubFetch(jsonResponse(400, {}));
+
+      await expect(createBugSplatClient(oauthArgs, host)).rejects.toThrow(
+        /status 400/
+      );
+    });
+
+    it('should throw when the response is not json', async () => {
+      stubFetch(new Response('<html>500</html>', { status: 500 }));
+
+      await expect(createBugSplatClient(oauthArgs, host)).rejects.toThrow(
+        /Could not authenticate/
+      );
+    });
+  });
+
+  describe('user and password', () => {
+    const userArgs = {
+      user: '🧑',
+      password: '🔑',
+      clientId: '',
+      clientSecret: '',
+    };
+
+    it('should return an authenticated client', async () => {
+      stubFetch(
+        new Response('{}', {
+          status: 200,
+          headers: { 'set-cookie': 'xsrf-token=token; path=/' },
+        })
+      );
+
+      const client = await createBugSplatClient(userArgs, host);
+
+      expect(client).toBeInstanceOf(BugSplatApiClient);
+    });
+
+    it('should throw for invalid credentials', async () => {
+      stubFetch(jsonResponse(401, { message: 'Authentication failure' }));
+
+      await expect(createBugSplatClient(userArgs, host)).rejects.toThrow(
+        /Could not authenticate/
+      );
+    });
+  });
+});
+
+function jsonResponse(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function stubFetch(response: Response): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(async () => response.clone())
+  );
+}

--- a/spec/auth.spec.ts
+++ b/spec/auth.spec.ts
@@ -4,7 +4,6 @@ import {
 } from '@bugsplat/js-api-client';
 import { vi } from 'vitest';
 import { createBugSplatClient } from '../src/auth';
-import { isAuthenticationError } from '../src/retry';
 
 describe('createBugSplatClient', () => {
   const host = 'https://app.bugsplat.com';
@@ -43,7 +42,7 @@ describe('createBugSplatClient', () => {
         (error) => error
       );
 
-      expect(isAuthenticationError(error)).toBe(true);
+      expect(error.isAuthenticationError).toBe(true);
     });
 
     it('should throw for an invalid client secret', async () => {
@@ -77,6 +76,40 @@ describe('createBugSplatClient', () => {
       await expect(createBugSplatClient(oauthArgs, host)).rejects.toThrow(
         /Could not authenticate/
       );
+    });
+
+    it('should rethrow network errors instead of blaming credentials', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockRejectedValue(new TypeError('fetch failed'))
+      );
+
+      await expect(createBugSplatClient(oauthArgs, host)).rejects.toThrow(
+        'fetch failed'
+      );
+    });
+
+    it('should return an authenticated client when the response can only be read once', async () => {
+      const response = jsonResponse(200, {
+        token_type: 'Bearer',
+        access_token: '🪙',
+      });
+      let reads = 0;
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation(async () => ({
+          status: response.status,
+          body: response.body,
+          clone: () =>
+            reads++ === 0
+              ? response.clone()
+              : { json: () => Promise.reject(new Error('body consumed')) },
+        }))
+      );
+
+      const client = await createBugSplatClient(oauthArgs, host);
+
+      expect(client).toBeInstanceOf(OAuthClientCredentialsClient);
     });
   });
 

--- a/spec/retry.spec.ts
+++ b/spec/retry.spec.ts
@@ -1,4 +1,4 @@
-import { BugSplatAuthenticationError } from '@bugsplat/js-api-client';
+import { BugSplatApiError, BugSplatAuthenticationError, BugSplatRateLimitError } from '@bugsplat/js-api-client';
 import { BrokenCircuitError } from 'cockatiel';
 import { vi } from 'vitest';
 import { createUploadRetryPolicy } from '../src/retry';
@@ -6,13 +6,12 @@ import { createUploadRetryPolicy } from '../src/retry';
 // Fast timings so retries/backoff resolve instantly in tests.
 const fast = { maxAttempts: 3, initialDelay: 1, maxDelay: 1, halfOpenAfter: 1, rateLimitThreshold: 1 };
 
-// Shape of a BugSplatApiError: an Error carrying the response status.
 function apiError(message: string, status: number) {
-    return Object.assign(new Error(message), { status });
+    return new BugSplatApiError(message, status);
 }
 
 function rateLimitError() {
-    return apiError('too many requests', 429);
+    return new BugSplatRateLimitError('too many requests');
 }
 
 describe('createUploadRetryPolicy', () => {
@@ -55,15 +54,6 @@ describe('createUploadRetryPolicy', () => {
 
         await expect(policy.execute(fn)).rejects.toThrow('transient');
         expect(fn).toHaveBeenCalledTimes(fast.maxAttempts + 1);
-    });
-
-    // Bridge for client versions predating the typed BugSplatApiError; remove with isUntypedForbiddenError.
-    it('should not retry the legacy untyped 403 error carrying no status', async () => {
-        const policy = createUploadRetryPolicy(fast);
-        const fn = vi.fn().mockRejectedValue(new Error('Error getting presigned URL, invalid credentials'));
-
-        await expect(policy.execute(fn)).rejects.toThrow('invalid credentials');
-        expect(fn).toHaveBeenCalledTimes(1);
     });
 
     it('should not retry max size errors', async () => {

--- a/spec/retry.spec.ts
+++ b/spec/retry.spec.ts
@@ -6,8 +6,13 @@ import { createUploadRetryPolicy } from '../src/retry';
 // Fast timings so retries/backoff resolve instantly in tests.
 const fast = { maxAttempts: 3, initialDelay: 1, maxDelay: 1, halfOpenAfter: 1, rateLimitThreshold: 1 };
 
+// Shape of a BugSplatApiError: an Error carrying the response status.
+function apiError(message: string, status: number) {
+    return Object.assign(new Error(message), { status });
+}
+
 function rateLimitError() {
-    return Object.assign(new Error('too many requests'), { status: 429 });
+    return apiError('too many requests', 429);
 }
 
 describe('createUploadRetryPolicy', () => {
@@ -33,6 +38,31 @@ describe('createUploadRetryPolicy', () => {
         const fn = vi.fn().mockRejectedValue(new BugSplatAuthenticationError('bad credentials'));
 
         await expect(policy.execute(fn)).rejects.toThrow('bad credentials');
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([400, 403, 404, 413])('should not retry %i, the request itself is the problem', async (status) => {
+        const policy = createUploadRetryPolicy(fast);
+        const fn = vi.fn().mockRejectedValue(apiError('rejected', status));
+
+        await expect(policy.execute(fn)).rejects.toThrow('rejected');
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([408, 500, 502, 503])('should retry %i, which can clear on its own', async (status) => {
+        const policy = createUploadRetryPolicy(fast);
+        const fn = vi.fn().mockRejectedValue(apiError('transient', status));
+
+        await expect(policy.execute(fn)).rejects.toThrow('transient');
+        expect(fn).toHaveBeenCalledTimes(fast.maxAttempts + 1);
+    });
+
+    // Bridge for client versions predating the typed BugSplatApiError; remove with isUntypedForbiddenError.
+    it('should not retry the legacy untyped 403 error carrying no status', async () => {
+        const policy = createUploadRetryPolicy(fast);
+        const fn = vi.fn().mockRejectedValue(new Error('Error getting presigned URL, invalid credentials'));
+
+        await expect(policy.execute(fn)).rejects.toThrow('invalid credentials');
         expect(fn).toHaveBeenCalledTimes(1);
     });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,7 +4,6 @@ import {
   BugSplatAuthenticationError,
   OAuthClientCredentialsClient,
 } from '@bugsplat/js-api-client';
-import { isAuthenticationError } from './retry';
 
 export interface AuthenticationArgs {
   user: string;
@@ -41,11 +40,13 @@ async function createAuthenticatedOAuthClient(
 
   // The authorize endpoint answers unknown client ids with an error payload instead of an
   // access_token, which would otherwise fail later with a confusing 401 in the middle of an upload.
-  if (!json?.access_token) {
+  // json() re-reads a clone of the authorize response; if that ever stops working, trust login()
+  // rather than reject an authentication that succeeded.
+  if (json && !json.access_token) {
     const detail =
-      json?.error_description ??
-      json?.message ??
-      json?.error ??
+      json.error_description ??
+      json.message ??
+      json.error ??
       `status ${response.status}`;
     throw new BugSplatAuthenticationError(
       createAuthenticationErrorMessage(detail)
@@ -59,13 +60,14 @@ async function login(client: OAuthClientCredentialsClient) {
   try {
     return await client.login();
   } catch (error) {
-    if (isAuthenticationError(error)) {
-      throw error;
+    // A non-JSON authorize response, a proxy error page for example, rejects inside login().
+    if (error instanceof SyntaxError) {
+      throw new BugSplatAuthenticationError(
+        createAuthenticationErrorMessage(error.message)
+      );
     }
 
-    throw new BugSplatAuthenticationError(
-      createAuthenticationErrorMessage((error as Error).message)
-    );
+    throw error;
   }
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,81 @@
+import {
+  ApiClient,
+  BugSplatApiClient,
+  BugSplatAuthenticationError,
+  OAuthClientCredentialsClient,
+} from '@bugsplat/js-api-client';
+import { isAuthenticationError } from './retry';
+
+export interface AuthenticationArgs {
+  user: string;
+  password: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+export async function createBugSplatClient(
+  { user, password, clientId, clientSecret }: AuthenticationArgs,
+  host: string | undefined = process.env.BUGSPLAT_HOST
+): Promise<ApiClient> {
+  if (user && password) {
+    return BugSplatApiClient.createAuthenticatedClientForNode(
+      user,
+      password,
+      host
+    );
+  }
+
+  return createAuthenticatedOAuthClient(clientId, clientSecret, host);
+}
+
+async function createAuthenticatedOAuthClient(
+  clientId: string,
+  clientSecret: string,
+  host: string | undefined
+): Promise<OAuthClientCredentialsClient> {
+  const client = new OAuthClientCredentialsClient(clientId, clientSecret, host);
+  const response = await login(client);
+  const json = (await response
+    .json()
+    .catch(() => null)) as OAuthLoginResult | null;
+
+  // The authorize endpoint answers unknown client ids with an error payload instead of an
+  // access_token, which would otherwise fail later with a confusing 401 in the middle of an upload.
+  if (!json?.access_token) {
+    const detail =
+      json?.error_description ??
+      json?.message ??
+      json?.error ??
+      `status ${response.status}`;
+    throw new BugSplatAuthenticationError(
+      createAuthenticationErrorMessage(detail)
+    );
+  }
+
+  return client;
+}
+
+async function login(client: OAuthClientCredentialsClient) {
+  try {
+    return await client.login();
+  } catch (error) {
+    if (isAuthenticationError(error)) {
+      throw error;
+    }
+
+    throw new BugSplatAuthenticationError(
+      createAuthenticationErrorMessage((error as Error).message)
+    );
+  }
+}
+
+function createAuthenticationErrorMessage(detail: string): string {
+  return `Could not authenticate, check credentials and try again: ${detail}`;
+}
+
+type OAuthLoginResult = {
+  access_token?: string;
+  error?: string;
+  error_description?: string;
+  message?: string;
+};

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,4 +1,4 @@
-import { BugSplatAuthenticationError } from '@bugsplat/js-api-client';
+import { BugSplatApiError, BugSplatAuthenticationError } from '@bugsplat/js-api-client';
 import {
     BrokenCircuitError,
     ConsecutiveBreaker,
@@ -23,19 +23,8 @@ export interface RetryPolicyOptions {
     rateLimitThreshold?: number;
 }
 
-/**
- * The HTTP status a failed upload request carries, if any.
- *
- * Read structurally rather than through `BugSplatApiError`: the declared @bugsplat/js-api-client floor
- * (^15.2.0) predates that class, so importing it wouldn't compile against every supported version.
- * See BugSplat-Git/bugsplat-js-api-client#174.
- */
-function statusOf(error: unknown): number | undefined {
-    return (error as { status?: number } | null)?.status;
-}
-
 export function isRateLimitError(error: unknown): boolean {
-    return statusOf(error) === 429;
+    return (error as BugSplatApiError | null)?.status === 429;
 }
 
 export function isAuthenticationError(error: unknown): boolean {
@@ -53,28 +42,13 @@ export function isMaxSizeExceededError(error: unknown): boolean {
  * exceptions: both clear on their own, and 429 additionally drives the circuit breaker below.
  */
 export function hasPermanentStatus(error: unknown): boolean {
-    const status = statusOf(error);
+    const status = (error as BugSplatApiError | null)?.status;
     return !!status && status >= 400 && status < 500 && status !== 408 && status !== 429;
-}
-
-/**
- * Bridge for @bugsplat/js-api-client versions predating BugSplat-Git/bugsplat-js-api-client#174, which
- * throw a bare Error for the 403 raised when credentials authenticate but aren't allowed to upload.
- * Those carry no status, so this legacy message is the only signal. Versions from #174 on carry a
- * status and a clearer message, and are caught by hasPermanentStatus — delete this once the dependency
- * floor moves past it.
- */
-function isUntypedForbiddenError(error: unknown): boolean {
-    const message = (error as Error | null)?.message ?? '';
-    return message.includes('Error getting presigned URL, invalid credentials');
 }
 
 // Permanent failures are worth failing fast on; retrying them just wastes requests against the rate limit.
 function isPermanent(error: unknown): boolean {
-    return hasPermanentStatus(error)
-        || isAuthenticationError(error)
-        || isMaxSizeExceededError(error)
-        || isUntypedForbiddenError(error);
+    return hasPermanentStatus(error) || isAuthenticationError(error) || isMaxSizeExceededError(error);
 }
 
 /**

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,4 +1,4 @@
-import { BugSplatAuthenticationError, BugSplatRateLimitError } from '@bugsplat/js-api-client';
+import { BugSplatAuthenticationError } from '@bugsplat/js-api-client';
 import {
     BrokenCircuitError,
     ConsecutiveBreaker,
@@ -23,8 +23,19 @@ export interface RetryPolicyOptions {
     rateLimitThreshold?: number;
 }
 
+/**
+ * The HTTP status a failed upload request carries, if any.
+ *
+ * Read structurally rather than through `BugSplatApiError`: the declared @bugsplat/js-api-client floor
+ * (^15.2.0) predates that class, so importing it wouldn't compile against every supported version.
+ * See BugSplat-Git/bugsplat-js-api-client#174.
+ */
+function statusOf(error: unknown): number | undefined {
+    return (error as { status?: number } | null)?.status;
+}
+
 export function isRateLimitError(error: unknown): boolean {
-    return (error as BugSplatRateLimitError | null)?.status === 429;
+    return statusOf(error) === 429;
 }
 
 export function isAuthenticationError(error: unknown): boolean {
@@ -36,9 +47,34 @@ export function isMaxSizeExceededError(error: unknown): boolean {
     return message.includes('Symbol file max size') || message.includes('Symbol table max size');
 }
 
-// Auth and max-size failures are permanent; retrying them just wastes requests against the rate limit.
+/**
+ * A 4xx means the request itself is the problem — wrong database, a client with the `restricted` scope,
+ * a file the server won't take — so resending it earns the same rejection. 408 and 429 are the
+ * exceptions: both clear on their own, and 429 additionally drives the circuit breaker below.
+ */
+export function hasPermanentStatus(error: unknown): boolean {
+    const status = statusOf(error);
+    return !!status && status >= 400 && status < 500 && status !== 408 && status !== 429;
+}
+
+/**
+ * Bridge for @bugsplat/js-api-client versions predating BugSplat-Git/bugsplat-js-api-client#174, which
+ * throw a bare Error for the 403 raised when credentials authenticate but aren't allowed to upload.
+ * Those carry no status, so this legacy message is the only signal. Versions from #174 on carry a
+ * status and a clearer message, and are caught by hasPermanentStatus — delete this once the dependency
+ * floor moves past it.
+ */
+function isUntypedForbiddenError(error: unknown): boolean {
+    const message = (error as Error | null)?.message ?? '';
+    return message.includes('Error getting presigned URL, invalid credentials');
+}
+
+// Permanent failures are worth failing fast on; retrying them just wastes requests against the rate limit.
 function isPermanent(error: unknown): boolean {
-    return isAuthenticationError(error) || isMaxSizeExceededError(error);
+    return hasPermanentStatus(error)
+        || isAuthenticationError(error)
+        || isMaxSizeExceededError(error)
+        || isUntypedForbiddenError(error);
 }
 
 /**


### PR DESCRIPTION
Closes #178

Unblocked by BugSplat-Git/bugsplat-js-api-client#174, released as `@bugsplat/js-api-client` 15.5.0 and consumed here.

## Problem

`POST /oauth2/authorize` only returns `{ "error": "invalid_client" }` when the **secret** is wrong. An **unknown client id** comes back as `400 { "message": "Unknown clientId ..." }`, which `@bugsplat/js-api-client` does not treat as an authentication failure — `login()` resolves, no access token is stored, and symbol-upload prints `Authentication success!` before every upload fails with a per-file auth error.

Verified against the live API:

| credentials | response |
| --- | --- |
| valid | `200 {"token_type":"Bearer","access_token":"..."}` |
| bad secret | `200 {"error":"invalid_client",...}` → already throws |
| unknown client id | `400 {"message":"Unknown clientId ..."}` → **misleading success** |

## Change

**Fail authentication at the authentication step.** Move client creation out of `bin/index.ts` into `src/auth.ts` and check the authorize response for an `access_token` before returning the client. When it's missing, throw a `BugSplatAuthenticationError` carrying the server's `error_description` / `message` / `error` (falling back to the status code). The user/password path is unchanged — it already throws on 401.

Before (unknown client id):

```
About to authenticate...
Authentication success!
Found files: ...
Worker 1 uploading windows.sym...
Upload request failed; backing off 519ms before retry...
```

After:

```
About to authenticate...
Could not authenticate, check credentials and try again: Unknown clientId 00000000000000000000000000000000
```
(exit code 1)

**Stop retrying permanently rejected uploads.** Reproducing the above on `main` surfaced a second bug: credentials that authenticate but can't upload (wrong database, or a client without upload access) come back 403, which `src/retry.ts` treated as transient — 15 retries per file with up to 30s backoff before the run gave up.

`isPermanent` now classifies by status: fail fast on 4xx, except 408 and 429, which clear on their own (and 429 drives the circuit breaker). That replaces a growing list of special cases with one rule, and covers 404/413 and anything future for free:

```ts
export function hasPermanentStatus(error: unknown): boolean {
    const status = (error as BugSplatApiError | null)?.status;
    return !!status && status >= 400 && status < 500 && status !== 408 && status !== 429;
}
```

That 403 previously arrived as a bare `Error` with no status, so classifying it needed a match on the message string. BugSplat-Git/bugsplat-js-api-client#174 made it a typed `BugSplatApiError`; this raises the floor to `^15.5.0` and drops the workaround.

## Verification

- `npx vitest run` — 80 passed
- `npx tsc --noEmit` and `npx tsc` — clean
- Ran the CLI against the live API with an unknown client id (output above) and with a valid client id/secret (authenticates and proceeds)
- `spec/auth.spec.ts` covers unknown client id, invalid secret, non-JSON responses, missing error details, transport failures, and both success paths; `spec/retry.spec.ts` asserts the retried/not-retried split over `[400, 403, 404, 413]` and `[408, 500, 502, 503]`, building fixtures from the real `BugSplatApiError` / `BugSplatRateLimitError` classes

## Known gap

`hasPermanentStatus` treats a 403 from the S3 presigned PUT as permanent, but the retry policy wraps the whole `postSymbols` call — which mints a fresh presigned URL each attempt — so an expired-URL 403 would in principle be recoverable. In practice the URL is minted and used within the same call and S3 checks expiry at request start, so a 403 there is far more likely to be bucket policy or clock skew, both genuinely permanent. Distinguishing the two needs the error to say which host answered; worth doing upstream if it ever shows up in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
