### PR TITLE
fix: let login() report authentication failures instead of re-reading the body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsplat/elfy": "^1.0.1",
-        "@bugsplat/js-api-client": "^15.5.0",
+        "@bugsplat/js-api-client": "^15.5.1",
         "archiver": "^8.0.0",
         "cockatiel": "^4.0.0",
         "command-line-args": "^5.2.0",
@@ -59,9 +59,9 @@
       "license": "MIT"
     },
     "node_modules/@bugsplat/js-api-client": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@bugsplat/js-api-client/-/js-api-client-15.5.0.tgz",
-      "integrity": "sha512-ScFMtYJEEIhdoHTVOz0/61T5C7b9NDrv1uRz2yaZs9pOb8aVimgZnVs7aXchUhnLnTyjBnDY/2qYhGu2D6RY1g==",
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/@bugsplat/js-api-client/-/js-api-client-15.5.1.tgz",
+      "integrity": "sha512-4QJDzAbTTDfEk25yeks52mmXK8dr65KcZ8MqJSQwj9IPLOF2lsTIHvI1A+NQtrD5PRj9fIm0ccw7LnlsX4eC8Q==",
       "license": "MIT",
       "dependencies": {
         "argument-contracts": "^1.2.3"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "dependencies": {
     "@bugsplat/elfy": "^1.0.1",
-    "@bugsplat/js-api-client": "^15.5.0",
+    "@bugsplat/js-api-client": "^15.5.1",
     "archiver": "^8.0.0",
     "cockatiel": "^4.0.0",
     "command-line-args": "^5.2.0",

--- a/spec/auth.spec.ts
+++ b/spec/auth.spec.ts
@@ -88,29 +88,6 @@ describe('createBugSplatClient', () => {
         'fetch failed'
       );
     });
-
-    it('should return an authenticated client when the response can only be read once', async () => {
-      const response = jsonResponse(200, {
-        token_type: 'Bearer',
-        access_token: '🪙',
-      });
-      let reads = 0;
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockImplementation(async () => ({
-          status: response.status,
-          body: response.body,
-          clone: () =>
-            reads++ === 0
-              ? response.clone()
-              : { json: () => Promise.reject(new Error('body consumed')) },
-        }))
-      );
-
-      const client = await createBugSplatClient(oauthArgs, host);
-
-      expect(client).toBeInstanceOf(OAuthClientCredentialsClient);
-    });
   });
 
   describe('user and password', () => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -32,52 +32,20 @@ async function createAuthenticatedOAuthClient(
   clientSecret: string,
   host: string | undefined
 ): Promise<OAuthClientCredentialsClient> {
-  const client = new OAuthClientCredentialsClient(clientId, clientSecret, host);
-  const response = await login(client);
-  const json = (await response
-    .json()
-    .catch(() => null)) as OAuthLoginResult | null;
-
-  // The authorize endpoint answers unknown client ids with an error payload instead of an
-  // access_token, which would otherwise fail later with a confusing 401 in the middle of an upload.
-  // json() re-reads a clone of the authorize response; if that ever stops working, trust login()
-  // rather than reject an authentication that succeeded.
-  if (json && !json.access_token) {
-    const detail =
-      json.error_description ??
-      json.message ??
-      json.error ??
-      `status ${response.status}`;
-    throw new BugSplatAuthenticationError(
-      createAuthenticationErrorMessage(detail)
-    );
-  }
-
-  return client;
-}
-
-async function login(client: OAuthClientCredentialsClient) {
   try {
-    return await client.login();
+    return await OAuthClientCredentialsClient.createAuthenticatedClient(
+      clientId,
+      clientSecret,
+      host
+    );
   } catch (error) {
     // A non-JSON authorize response, a proxy error page for example, rejects inside login().
     if (error instanceof SyntaxError) {
       throw new BugSplatAuthenticationError(
-        createAuthenticationErrorMessage(error.message)
+        `Could not authenticate, check credentials and try again: ${error.message}`
       );
     }
 
     throw error;
   }
 }
-
-function createAuthenticationErrorMessage(detail: string): string {
-  return `Could not authenticate, check credentials and try again: ${detail}`;
-}
-
-type OAuthLoginResult = {
-  access_token?: string;
-  error?: string;
-  error_description?: string;
-  message?: string;
-};


### PR DESCRIPTION
## Problem

`src/auth.ts` was doing the library's job for it. After `login()` resolved it re-read the authorize response and checked for an `access_token`:

```ts
const response = await login(client);
const json = (await response.json().catch(() => null)) as OAuthLoginResult | null;

if (json && !json.access_token) {
    const detail = json.error_description ?? json.message ?? json.error ?? `status ${response.status}`;
    throw new BugSplatAuthenticationError(createAuthenticationErrorMessage(detail));
}
```

That existed because `login()` only rejected when the payload said `error: 'invalid_client'` — the bad-secret case. An unknown client id came back `400 { "message": "Unknown clientId ..." }` and sailed through, so `login()` resolved with no token stored.

The workaround had two problems:

1. **It depended on a private implementation detail.** Re-reading only worked because `BugSplatResponse.json()` is `response.clone().json()`. Nothing guaranteed that. The guard was deliberately written as `if (json && !json.access_token)` — trust `login()` rather than false-fail a valid login — precisely because the clone could go away.
2. **It was a local fix for everyone's bug.** Every other consumer of the library still authenticated against a client that silently held no token.

## Change

BugSplat-Git/bugsplat-js-api-client#176 makes `login()` reject when the response carries no `access_token`, and surface the server's detail. It shipped in **15.5.1**, so all of this can go: the re-read, the `OAuthLoginResult` type, the `createAuthenticationErrorMessage` helper, and the guard.

What's left is the library's own factory plus the one thing it genuinely can't cover:

```ts
try {
    return await OAuthClientCredentialsClient.createAuthenticatedClient(clientId, clientSecret, host);
} catch (error) {
    // A non-JSON authorize response, a proxy error page for example, rejects inside login().
    if (error instanceof SyntaxError) {
        throw new BugSplatAuthenticationError(
            `Could not authenticate, check credentials and try again: ${error.message}`
        );
    }

    throw error;
}
```

Every user-facing message is unchanged — `login()` now produces the same `Could not authenticate, check credentials and try again: Unknown clientId ...` this file was assembling by hand, so the CLI output is identical.

Also drops the `should return an authenticated client when the response can only be read once` spec. It existed solely to prove the re-read degraded safely when the body couldn't be read twice; with no re-read there's nothing left to degrade.

## Verification

Dependency floor moved to `^15.5.1`. Against the published release:

- `npx tsc --noEmit` clean
- `npx vitest run` — **79 passed**

The three specs that were red on the old floor now pass on the library's own behavior rather than this file's:

```
✓ should throw for an unknown client id
✓ should throw an authentication error when no access token is returned
✓ should throw with the response status when the response has no error details
```

## Rebase note

This branch was conflicting because it predated #208. Its other two commits (the retry.ts 403 / typed-error work) had already reached main by other routes, so the only content left was the `src/auth.ts` and `spec/auth.spec.ts` change. Rebuilt as a single commit on top of current main, plus the `^15.5.1` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)