### PR TITLE
feat!: remove username and password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,60 +69,69 @@ Run `symbol-upload` with `-h` to see the latest usage information and package ve
 ```bash
 bobby@BugSplat % ~ % symbol-upload -h
 
-@bugsplat/symbol-upload v10.2.0
+@bugsplat/symbol-upload v10.5.2
 
   symbol-upload contains a command line utility and a set of libraries to help  
   you upload symbol files to BugSplat.                                          
 
 Usage
 
-  -h, --help                             Print this usage guide.                                                       
-  -b, --database string                  Your BugSplat database name. The value of database must match the value used  
-                                         to post crash reports. This value can also be provided via the                
-                                         BUGSPLAT_DATABASE environment variable.                                       
-  -a, --application string               The name of your application. If not provided symbol-upload will attempt to   
-                                         use the value of the name field in package.json if it exists in the current   
-                                         working directory.                                                            
-  -v, --version string                   Your application's version. If not provided symbol-upload will attempt to use 
-                                         the value of the version field in package.json if it exists in the current    
-                                         working directory.                                                            
-  -u, --user string (optional)           The email address used to log into your BugSplat account. If provided         
-                                         --password must also be provided. This value can also be provided via the     
-                                         SYMBOL_UPLOAD_USER environment variable.                                      
-  -p, --password string (optional)       The password for your BugSplat account. If provided --user must also be       
-                                         provided. This value can also be provided via the SYMBOL_UPLOAD_PASSWORD      
-                                         environment variable.                                                         
-  -i, --clientId string (optional)       An OAuth2 Client Credentials Client ID for the specified database. If         
-                                         provided --clientSecret must also be provided. This value can also be         
-                                         provided via the SYMBOL_UPLOAD_CLIENT_ID environment variable.                
-  -s, --clientSecret string (optional)   An OAuth2 Client Credentials Client Secret for the specified database. If     
-                                         provided --clientId must also be provided. This value can also be provided    
-                                         via the SYMBOL_UPLOAD_CLIENT_SECRET environment variable.                     
-  -r, --remove                           Removes symbols for a specified database, application, and version. If this   
-                                         option is provided no other actions are taken.                                
-  -f, --files string (optional)          Glob pattern that specifies a set of files to upload. For example,            
-                                         **/*.{pdb,exe,dll} will recursively search for .pdb, .exe, and .dll files.    
-                                         Defaults to "*.js.map"                                                        
-  -d, --directory string (optional)      Path of the base directory used to search for symbol files. This value will   
-                                         be combined with the --files glob. Defaults to '.'                            
-  -m, --dumpSyms boolean (optional)      Use dump_syms to generate and upload sym files for specified binaries.        
-  -l, --localPath string (optional)      Path to a directory to copy symbols to. If provided, the files will be copied   
-                                         to the provided path instead of being uploaded to BugSplat. Useful for        
-                                         creating a self-hosted symbol server.                                         
+  -h, --help                          Print this usage guide.                   
+  -b, --database string               Your BugSplat database name. The value of 
+                                      database must match the value used to     
+                                      post crash reports. This value can also   
+                                      be provided via the BUGSPLAT_DATABASE     
+                                      environment variable.                     
+  -a, --application string            The name of your application. If not      
+                                      provided symbol-upload will attempt to    
+                                      use the value of the name field in        
+                                      package.json if it exists in the current  
+                                      working directory.                        
+  -v, --version string                Your application's version. If not        
+                                      provided symbol-upload will attempt to    
+                                      use the value of the version field in     
+                                      package.json if it exists in the current  
+                                      working directory.                        
+  -i, --clientId string               An OAuth2 Client Credentials Client ID    
+                                      for the specified database. If provided   
+                                      --clientSecret must also be provided.     
+                                      This value can also be provided via the   
+                                      SYMBOL_UPLOAD_CLIENT_ID environment       
+                                      variable.                                 
+  -s, --clientSecret string           An OAuth2 Client Credentials Client       
+                                      Secret for the specified database. If     
+                                      provided --clientId must also be          
+                                      provided. This value can also be provided 
+                                      via the SYMBOL_UPLOAD_CLIENT_SECRET       
+                                      environment variable.                     
+  -r, --remove                        Removes symbols for a specified database, 
+                                      application, and version. If this option  
+                                      is provided no other actions are taken.   
+  -f, --files string (optional)       Glob pattern that specifies a set of      
+                                      files to upload. For example,             
+                                      **/*.{pdb,exe,dll} will recursively       
+                                      search for .pdb, .exe, and .dll files.    
+                                      Defaults to "*.js.map"                    
+  -d, --directory string (optional)   Path of the base directory used to search 
+                                      for symbol files. This value will be      
+                                      combined with the --files glob. Defaults  
+                                      to '.'                                    
+  -m, --dumpSyms boolean (optional)   Use dump_syms to generate and upload sym  
+                                      files for specified binaries.             
+  -l, --localPath string (optional)   Path to a directory to copy symbols to.   
+                                      If provided, the files will be copied to  
+                                      the provided path instead of being        
+                                      uploaded to BugSplat. Useful for creating 
+                                      a self-hosted symbol server.              
 
-  The -u and -p arguments are not required if you set the environment variables 
-  SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD, or provide a clientId and      
-  clientSecret.                                                                 
-                                                                                
   The -i and -s arguments are not required if you set the environment variables 
-  SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET, or provide a user    
-  and password.                                                                 
+  SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET.                      
 
 Example
 
   symbol-upload -b your-bugsplat-database -a your-application-name -v your-     
-  version [ -f "*.js.map" -d "/path/to/containing/dir" [ -u your-bugsplat-email 
-  -p your-bugsplat-password ] OR [ -i your-client-id -s your-client-secret] ]   
+  version -i your-client-id -s your-client-secret [ -f "*.js.map" -d            
+  "/path/to/containing/dir" ]                                                   
 
 Links
 
@@ -130,7 +139,7 @@ Links
                                                    
   💻 https://github.com/BugSplat-Git/symbol-upload 
                                                    
-  💌 support@bugsplat.com  
+  💌 support@bugsplat.com
 ```
 
 Run symbol-upload specifying a [glob](https://www.npmjs.com/package/glob#glob-primer) pattern for `-f` and a path with forward slashes for `-d`. Multiple file types can be specified in curly brackets separated by a comma, and wildcards can be used to search directories recursively. For example, `**/*.{pdb,exe,dll}` will search for all `.pdb`, `.exe`, and `.dll` files in the current directory and all subdirectories. Optionally, you can specify the `-m` flag to run [dump_syms](https://github.com/BugSplat-Git/node-dump-syms) against the specified binaries and upload the resulting `.sym` files.
@@ -167,21 +176,17 @@ This package supports both ES modules (ESM) and CommonJS (CJS) formats. You can 
 
 **ES Modules (ESM):**
 ```ts
-import { BugSplatApiClient, OAuthClientCredentialsClient, uploadSymbolFiles } from '@bugsplat/symbol-upload';
+import { OAuthClientCredentialsClient, uploadSymbolFiles } from '@bugsplat/symbol-upload';
 ```
 
 **CommonJS (CJS):**
 ```js
-const { BugSplatApiClient, OAuthClientCredentialsClient, uploadSymbolFiles } = require('@bugsplat/symbol-upload');
+const { OAuthClientCredentialsClient, uploadSymbolFiles } = require('@bugsplat/symbol-upload');
 ```
 
-Import `BugSplatApiClient` and `VersionsApiClient` from @bugsplat/symbol-upload. Alternatively, you can import `OAuthClientCredentialsClient` if you'd prefer to authenticate with an [OAuth2 Client Credentials](https://docs.bugsplat.com/introduction/development/web-services/oauth2#client-credentials) Client ID and Client Secret.
+Import `OAuthClientCredentialsClient` from @bugsplat/symbol-upload and authenticate with an [OAuth2 Client Credentials](https://docs.bugsplat.com/introduction/development/web-services/oauth2#client-credentials) Client ID and Client Secret.
 
-Create a new instance of `BugSplatApiClient` using the `createAuthenticatedClientForNode` async factory function or `OAuthClientCredentialsClient` using the `createAuthenticatedClient` async factory function.
-
-```ts
-const bugsplat = await BugSplatApiClient.createAuthenticatedClientForNode(email, password);
-```
+Create a new instance of `OAuthClientCredentialsClient` using the `createAuthenticatedClient` async factory function.
 
 ```ts
 const bugsplat = await OAuthClientCredentialsClient.createAuthenticatedClient(clientId, clientSecret);

--- a/action.yaml
+++ b/action.yaml
@@ -6,23 +6,14 @@ branding:
   color: 'blue'
 
 inputs:
-  # Either username & password must be provided, or clientId & clientSecret.
-  username:
-    description: "BugSplat account username"
-    type: string
-    required: false
-  password:
-    description: "BugSplat account password"
-    type: string
-    required: false
   clientId:
     description: "OAuth2 Client Credentials Client ID"
     type: string
-    required: false
+    required: true
   clientSecret:
     description: "OAuth2 Client Credentials Client Secret"
     type: string
-    required: false
+    required: true
   database:
     description: "BugSplat crash database"
     type: string
@@ -79,8 +70,6 @@ runs:
         -b "${{ inputs.database }}"
         -a "${{ inputs.application }}"
         -v "${{ inputs.version }}"
-        -u "${{ inputs.username }}"
-        -p "${{ inputs.password }}"
         -i "${{ inputs.clientId }}"
         -s "${{ inputs.clientSecret }}"
         -f "${{ inputs.files }}"

--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -37,31 +37,17 @@ export const argDefinitions: Array<CommandLineDefinition> = [
         description: 'Your application\'s version. If not provided symbol-upload will attempt to use the value of the version field in package.json if it exists in the current working directory.',
     },
     {
-        name: 'user',
-        alias: 'u',
-        type: String,
-        typeLabel: '{underline string} (optional)',
-        description: 'The email address used to log into your BugSplat account. If provided --password must also be provided. This value can also be provided via the SYMBOL_UPLOAD_USER environment variable.',
-    },
-    {
-        name: 'password',
-        alias: 'p',
-        type: String,
-        typeLabel: '{underline string} (optional)',
-        description: 'The password for your BugSplat account. If provided --user must also be provided. This value can also be provided via the SYMBOL_UPLOAD_PASSWORD environment variable.',
-    },
-    {
         name: 'clientId',
         alias: 'i',
         type: String,
-        typeLabel: '{underline string} (optional)',
+        typeLabel: '{underline string}',
         description: 'An OAuth2 Client Credentials Client ID for the specified database. If provided --clientSecret must also be provided. This value can also be provided via the SYMBOL_UPLOAD_CLIENT_ID environment variable.',
     },
     {
         name: 'clientSecret',
         alias: 's',
         type: String,
-        typeLabel: '{underline string} (optional)',
+        typeLabel: '{underline string}',
         description: 'An OAuth2 Client Credentials Client Secret for the specified database. If provided --clientId must also be provided. This value can also be provided via the SYMBOL_UPLOAD_CLIENT_SECRET environment variable.',
     },
     {
@@ -115,15 +101,13 @@ export const usageDefinitions: Array<Section> = [
     },
     {
         content: [
-            'The -u and -p arguments are not required if you set the environment variables SYMBOL_UPLOAD_USER and SYMBOL_UPLOAD_PASSWORD, or provide a clientId and clientSecret.',
-            '',
-            'The -i and -s arguments are not required if you set the environment variables SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET, or provide a user and password.'
+            'The -i and -s arguments are not required if you set the environment variables SYMBOL_UPLOAD_CLIENT_ID and SYMBOL_UPLOAD_CLIENT_SECRET.'
         ]
     },
     {
         header: 'Example',
         content: [
-            'symbol-upload -b {italic your-bugsplat-database} -a {italic your-application-name} -v {italic your-version} [ -f "*.js.map" -d "/path/to/containing/dir" [ -u {italic your-bugsplat-email} -p {italic your-bugsplat-password} ] OR [ -i {italic your-client-id} -s {italic your-client-secret}] ]',
+            'symbol-upload -b {italic your-bugsplat-database} -a {italic your-application-name} -v {italic your-version} -i {italic your-client-id} -s {italic your-client-secret} [ -f "*.js.map" -d "/path/to/containing/dir" ]',
         ]
     },
     {

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -30,8 +30,6 @@ import {
     database,
     application,
     version,
-    user,
-    password,
     clientId,
     clientSecret,
     remove,
@@ -47,8 +45,6 @@ import {
   }
 
   database = database ?? process.env.BUGSPLAT_DATABASE;
-  user = user ?? process.env.SYMBOL_UPLOAD_USER;
-  password = password ?? process.env.SYMBOL_UPLOAD_PASSWORD;
   clientId = clientId ?? process.env.SYMBOL_UPLOAD_CLIENT_ID;
   clientSecret = clientSecret ?? process.env.SYMBOL_UPLOAD_CLIENT_SECRET;
 
@@ -70,8 +66,6 @@ import {
   if (
     !localPath &&
     !validAuthenticationArguments({
-      user,
-      password,
       clientId,
       clientSecret,
     })
@@ -88,8 +82,6 @@ import {
     console.log('About to authenticate...');
 
     bugsplat = await createBugSplatClient({
-      user,
-      password,
       clientId,
       clientSecret,
     });
@@ -280,7 +272,7 @@ function logMissingArg(arg: string): void {
 
 function logMissingAuth(): void {
   console.log(
-    '\nInvalid authentication arguments: please provide either a user and password, or a clientId and clientSecret\n'
+    '\nInvalid authentication arguments: please provide a clientId and clientSecret\n'
   );
   logHelp();
   process.exitCode = 1;
@@ -291,10 +283,8 @@ function normalizeDirectory(directory: string): string {
 }
 
 function validAuthenticationArguments({
-  user,
-  password,
   clientId,
   clientSecret,
 }: AuthenticationArgs): boolean {
-  return !!(user && password) || !!(clientId && clientSecret);
+  return !!(clientId && clientSecret);
 }

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,6 @@ export type {
 } from '@bugsplat/js-api-client';
 
 export {
-    BugSplatApiClient,
     VersionsApiClient,
     SymbolsApiClient,
     OAuthClientCredentialsClient

--- a/spec/auth.spec.ts
+++ b/spec/auth.spec.ts
@@ -1,15 +1,10 @@
-import {
-  BugSplatApiClient,
-  OAuthClientCredentialsClient,
-} from '@bugsplat/js-api-client';
+import { OAuthClientCredentialsClient } from '@bugsplat/js-api-client';
 import { vi } from 'vitest';
 import { createBugSplatClient } from '../src/auth';
 
 describe('createBugSplatClient', () => {
   const host = 'https://app.bugsplat.com';
   const oauthArgs = {
-    user: '',
-    password: '',
     clientId: '🎫',
     clientSecret: '🔐',
   };
@@ -86,36 +81,6 @@ describe('createBugSplatClient', () => {
 
       await expect(createBugSplatClient(oauthArgs, host)).rejects.toThrow(
         'fetch failed'
-      );
-    });
-  });
-
-  describe('user and password', () => {
-    const userArgs = {
-      user: '🧑',
-      password: '🔑',
-      clientId: '',
-      clientSecret: '',
-    };
-
-    it('should return an authenticated client', async () => {
-      stubFetch(
-        new Response('{}', {
-          status: 200,
-          headers: { 'set-cookie': 'xsrf-token=token; path=/' },
-        })
-      );
-
-      const client = await createBugSplatClient(userArgs, host);
-
-      expect(client).toBeInstanceOf(BugSplatApiClient);
-    });
-
-    it('should throw for invalid credentials', async () => {
-      stubFetch(jsonResponse(401, { message: 'Authentication failure' }));
-
-      await expect(createBugSplatClient(userArgs, host)).rejects.toThrow(
-        /Could not authenticate/
       );
     });
   });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,36 +1,16 @@
 import {
-  ApiClient,
-  BugSplatApiClient,
   BugSplatAuthenticationError,
   OAuthClientCredentialsClient,
 } from '@bugsplat/js-api-client';
 
 export interface AuthenticationArgs {
-  user: string;
-  password: string;
   clientId: string;
   clientSecret: string;
 }
 
 export async function createBugSplatClient(
-  { user, password, clientId, clientSecret }: AuthenticationArgs,
+  { clientId, clientSecret }: AuthenticationArgs,
   host: string | undefined = process.env.BUGSPLAT_HOST
-): Promise<ApiClient> {
-  if (user && password) {
-    return BugSplatApiClient.createAuthenticatedClientForNode(
-      user,
-      password,
-      host
-    );
-  }
-
-  return createAuthenticatedOAuthClient(clientId, clientSecret, host);
-}
-
-async function createAuthenticatedOAuthClient(
-  clientId: string,
-  clientSecret: string,
-  host: string | undefined
 ): Promise<OAuthClientCredentialsClient> {
   try {
     return await OAuthClientCredentialsClient.createAuthenticatedClient(


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #210** — based on `claude/drop-authorize-reread` so the diff shows only this change. GitHub will retarget it to `main` automatically when #210 merges. Companion to BugSplat-Git/bugsplat-js-api-client#177, which removes username/password auth from the client library.

BugSplat no longer supports username and password authentication.

## CLI

- `--user`/`-u` and `--password`/`-p` removed
- `SYMBOL_UPLOAD_USER` and `SYMBOL_UPLOAD_PASSWORD` no longer read
- `AuthenticationArgs` is now `{ clientId, clientSecret }`
- Missing-auth message is now `please provide a clientId and clientSecret`
- `--clientId`/`--clientSecret` are no longer labeled optional in the usage guide, since they're the only way to authenticate

Anyone still passing `-u` gets `Unknown option: -u` from command-line-args.

Combined with #210, `createBugSplatClient` reduces to the library's factory plus the `SyntaxError` catch:

```ts
export async function createBugSplatClient(
  { clientId, clientSecret }: AuthenticationArgs,
  host: string | undefined = process.env.BUGSPLAT_HOST
): Promise<OAuthClientCredentialsClient> {
  try {
    return await OAuthClientCredentialsClient.createAuthenticatedClient(clientId, clientSecret, host);
  } catch (error) {
    // A non-JSON authorize response, a proxy error page for example, rejects inside login().
    if (error instanceof SyntaxError) {
      throw new BugSplatAuthenticationError(
        `Could not authenticate, check credentials and try again: ${error.message}`
      );
    }

    throw error;
  }
}
```

## Action

`username` and `password` inputs are gone and no longer forwarded to the CLI. `clientId` and `clientSecret` are now `required: true`. Workflows still passing `username`/`password` will get GitHub's "Unexpected input(s)" warning rather than a failure.

## Exports

`BugSplatApiClient` is dropped from `index.ts`. Once BugSplat-Git/bugsplat-js-api-client#177 ships, it can't authenticate in Node, so handing one to `uploadSymbolFiles` would only produce a 401 — exporting it would be a trap.

## README

The usage block is regenerated from real `--help` output rather than hand-edited, so it also picks up the stale `v10.2.0` header and the column re-wrap.

## Verification

`npx tsc --noEmit` clean, `npx vitest run` green at 77 tests (79 on the #210 base, minus the two user/password specs this removes).

Checked by hand:

```
$ symbol-upload -b db -a app -v 1.0
Invalid authentication arguments: please provide a clientId and clientSecret

$ symbol-upload -b db -a app -v 1.0 -u me@x.com -p pw
Unknown option: -u
```

Note: `symbol-upload-version` in `action.yaml` still defaults to `10.3.1` and should be bumped once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)